### PR TITLE
6.x

### DIFF
--- a/islandora_solr_search.admin.inc
+++ b/islandora_solr_search.admin.inc
@@ -92,22 +92,66 @@ function islandora_solr_admin_settings(&$form_state) {
   }
 
 
+  // get the table settings
+  $primary_display_array = variable_get('islandora_solr_primary_display_array', array());
 
+  $enabled = array();
+  
+  // set the table form items
+  $form['islandora_solr_primary_display_array'] = array(
+    '#tree' => TRUE, // this attribute is important to return the submitted values in a deeper nested arrays in
+  );
 
   $profiles = module_invoke_all("islandora_solr_primary_display");
-  uksort($profiles, "sort_default_first");
-  foreach ($profiles as $machine_name => $profile) {
-    $islandora_solr_primary_display_options[$machine_name] = $profile['name'];
-  }
+  
+  if (!empty($profiles)) {
+    
+    $profiles_sorted = array();
+    // if the table settings are set (weight), we change the order of the table rows.
+    if(isset($primary_display_array['weight'])) {
+      asort($primary_display_array['weight']);
+      foreach($primary_display_array['weight'] as $key => $value) {
+        $profiles_sorted[$key] = $profiles[$key];
+      }
+    }
+    // or else use the default
+    else {
+      uksort($profiles, "sort_default_first"); // only apply when there's no sort variable available.
+      $profiles_sorted = $profiles;
+    }
+    
+    // table loop
+    foreach ($profiles_sorted as $machine_name => $profile) {
+    
+      $options[$machine_name] = '';
 
-  if (!empty($islandora_solr_primary_display_options)) {
-    $form['islandora_solr_primary_display'] = array(
+      $form['islandora_solr_primary_display_array']['name'][$machine_name] = array(
+        '#value' => $profile['name'],
+      );
+      $form['islandora_solr_primary_display_array']['machine_name'][$machine_name] = array(
+        '#value' => $machine_name,      
+      );
+      $form['islandora_solr_primary_display_array']['weight'][$machine_name] = array(
+        '#type' => 'weight',
+        '#default_value' => ($primary_display_array['weight'][$machine_name]) ? $primary_display_array['weight'][$machine_name] : 0,
+      );
+      $form['islandora_solr_primary_display_array']['configuration'][$machine_name] = array(
+        '#value' => (isset($profile['configuration']) AND $profile['configuration'] != '') ? l(t('configure'), $profile['configuration']): '',              
+      );
+    }
+    
+    $form['islandora_solr_primary_display_array']['default'] = array(
       '#type' => 'radios',
-      '#title' => t('Default Display Profile'),
-      '#options' => $islandora_solr_primary_display_options,
+      '#options' => $options,
       '#default_value' => variable_get('islandora_solr_primary_display', 'default'),
-      '#description' => "Preferred normal display profile for search results.  These may be provided by third-party modules. ",
     );
+    $form['islandora_solr_primary_display_array']['enabled'] = array(
+      '#type' => 'checkboxes',
+      '#options' => $options,
+      '#default_value' => (!empty($primary_display_array)) ? $primary_display_array['enabled'] : $primary_display_array, // $primary_display_array['enabled'][$machine_name]
+    );    
+    
+    
   }
 
   $profiles = module_invoke_all("islandora_solr_secondary_display");
@@ -155,7 +199,7 @@ function islandora_solr_admin_settings(&$form_state) {
   $form['sort_fields']['islandora_solr_search_sort_order'] = array(
     '#type' => 'radios',
     '#title' => t('Sort Order'),
-    '#options' => array('asc' => t('Accending'), 'desc' => t('Decending')),
+    '#options' => array('asc' => t('Ascending'), 'desc' => t('Decending')),
     '#default_value' => 'desc',
   );
 
@@ -250,11 +294,69 @@ function islandora_solr_admin_settings(&$form_state) {
     drupal_set_message(t('The settings have not been saved because of the errors.'), 'error');
   }
   $form['#submit'][] = 'solr_settings_form_submit';
-  $form['#theme'] = 'system_settings_form';
-
+  //$form['#theme'] = 'system_settings_form';
+  $form['#theme'] = 'islandora_solr_search_admin_settings';
 
   return ($form);
 }
+
+
+/**
+ * theme_islandora_solr_search_admin_settings()
+ */
+function theme_islandora_solr_search_admin_settings($form){
+  //dsm($form);
+  $default = variable_get('islandora_solr_primary_display', 'default');
+  $rows = array();
+ 
+  foreach ($form['islandora_solr_primary_display_array']['machine_name'] as $key => $element) {
+    $row = array();
+    // check if $key is really the array we need. we shouldn't select the #parent array for example.
+    if (is_array($element) && element_child($key)) {
+ 
+      if ($key == $default) {
+        $form['islandora_solr_primary_display_array']['enabled'][$key]['#attributes']['disabled'] = 'disabled';
+        $form['islandora_solr_primary_display_array']['enabled'][$key]['#value'] = TRUE;
+      }
+      
+      $row[] = array('data' => drupal_render($form['islandora_solr_primary_display_array']['default'][$key]));
+      $row[] = array('data' => drupal_render($form['islandora_solr_primary_display_array']['enabled'][$key]));
+      $row[] = array('data' => drupal_render($form['islandora_solr_primary_display_array']['name'][$key]));
+      $row[] = array('data' => drupal_render($form['islandora_solr_primary_display_array']['machine_name'][$key]));
+      $row[] = array('data' => drupal_render($form['islandora_solr_primary_display_array']['weight'][$key]));
+      $row[] = array('data' => drupal_render($form['islandora_solr_primary_display_array']['configuration'][$key]));
+ 
+      $rows[] = $row;
+    }
+  }
+  
+  // Individual table headers.
+  // default | enabled | name | Machine readable name |  weight | configuration
+  $header = array();
+  $header[] = t('default');
+  $header[] = t('enabled');
+  $header[] = t('name');
+  $header[] = t('machine readable name');
+  $header[] = t('weight');
+  $header[] = t('configuration');
+  
+  // put the rendered table in another fieldset.
+  $form['islandora_solr_primary_display_array']['#type'] = 'item';
+  $form['islandora_solr_primary_display_array']['#title'] = t('Primary Display Profile');
+  $form['islandora_solr_primary_display_array']['#description'] = t('Preferred normal display profile for search results.  These may be provided by third-party modules.');
+  $form['islandora_solr_primary_display_array']['#value'] = theme('table', $header, $rows);
+
+  //dsm($form);
+  
+  // render form
+  $output = '';
+  $output .= drupal_render($form);
+  //dsm($form);
+  return $output;
+}
+
+
+
 
 /**
  *
@@ -360,13 +462,23 @@ function callback_prep() {
 }
 
 /**
- * Solr settings from submin
+ * Solr settings from submit
  * @param array $form
  * @param array $form_state
  * @return NULL
  */
 function solr_settings_form_submit($form, &$form_state) {
+  //dsm($form_state);
 
+  // old_default variable
+  $old_default = variable_get('islandora_solr_primary_display', 'default');
+  // new_default variable
+  $new_default = $form_state['values']['islandora_solr_primary_display_array']['default'];
+  // make default enabled
+  $form_state['values']['islandora_solr_primary_display_array']['enabled'][$new_default] = $new_default;
+  $form_state['values']['islandora_solr_primary_display_array']['enabled'][$old_default] = $old_default;
+  variable_set('islandora_solr_primary_display', $new_default);
+  
   if ($form_state['clicked_button']['#id'] != 'edit-submit') {
     $form_state['rebuild'] = TRUE;
     return;

--- a/islandora_solr_search.admin.inc
+++ b/islandora_solr_search.admin.inc
@@ -105,20 +105,37 @@ function islandora_solr_admin_settings(&$form_state) {
   $profiles = module_invoke_all("islandora_solr_primary_display");
   
   if (!empty($profiles)) {
-    
+        
     $profiles_sorted = array();
     // if the table settings are set (weight), we change the order of the table rows.
     if(isset($primary_display_array['weight'])) {
-      asort($primary_display_array['weight']);
-      foreach($primary_display_array['weight'] as $key => $value) {
-        $profiles_sorted[$key] = $profiles[$key];
+      // new variable
+      $weight = $primary_display_array['weight'];
+      
+      // check if all values are unique
+      if(count(array_unique($weight)) == 1) {
+        // sort alphabetically with default on top
+        uksort($profiles, "sort_default_first");
+        $profiles_sorted = $profiles;
+      }
+      else{
+        // First sort by value and then sort equal values by key: http://stackoverflow.com/a/6611077/477949
+        array_multisort(array_values($weight), SORT_ASC, array_keys($weight), SORT_ASC, $weight);
+
+        // re-order the array
+        foreach($weight as $key => $value) {
+          $profiles_sorted[$key] = $profiles[$key];
+        }
       }
     }
     // or else use the default
     else {
+      // sort alphabetically with default on top
       uksort($profiles, "sort_default_first"); // only apply when there's no sort variable available.
       $profiles_sorted = $profiles;
     }
+    
+    
     
     // table loop
     foreach ($profiles_sorted as $machine_name => $profile) {

--- a/islandora_solr_search.admin.inc
+++ b/islandora_solr_search.admin.inc
@@ -350,12 +350,12 @@ function theme_islandora_solr_search_admin_settings($form){
   // Individual table headers.
   // default | enabled | name | Machine readable name |  weight | configuration
   $header = array();
-  $header[] = t('default');
-  $header[] = t('enabled');
-  $header[] = t('name');
-  $header[] = t('machine readable name');
-  $header[] = t('weight');
-  $header[] = t('configuration');
+  $header[] = t('Default');
+  $header[] = t('Enabled');
+  $header[] = t('Name');
+  $header[] = t('Machine readable name');
+  $header[] = t('Weight');
+  $header[] = t('Configuration');
   
   // put the rendered table in another fieldset.
   $form['islandora_solr_primary_display_array']['#type'] = 'item';

--- a/islandora_solr_search.admin.inc
+++ b/islandora_solr_search.admin.inc
@@ -93,12 +93,12 @@ function islandora_solr_admin_settings(&$form_state) {
 
 
   // get the table settings
-  $primary_display_array = variable_get('islandora_solr_primary_display_array', array());
+  $primary_display_array = variable_get('islandora_solr_primary_display_table', array());
 
   $enabled = array();
   
   // set the table form items
-  $form['islandora_solr_primary_display_array'] = array(
+  $form['islandora_solr_primary_display_table'] = array(
     '#tree' => TRUE, // this attribute is important to return the submitted values in a deeper nested arrays in
   );
 
@@ -142,27 +142,27 @@ function islandora_solr_admin_settings(&$form_state) {
     
       $options[$machine_name] = '';
 
-      $form['islandora_solr_primary_display_array']['name'][$machine_name] = array(
+      $form['islandora_solr_primary_display_table']['name'][$machine_name] = array(
         '#value' => $profile['name'],
       );
-      $form['islandora_solr_primary_display_array']['machine_name'][$machine_name] = array(
+      $form['islandora_solr_primary_display_table']['machine_name'][$machine_name] = array(
         '#value' => $machine_name,      
       );
-      $form['islandora_solr_primary_display_array']['weight'][$machine_name] = array(
+      $form['islandora_solr_primary_display_table']['weight'][$machine_name] = array(
         '#type' => 'weight',
         '#default_value' => ($primary_display_array['weight'][$machine_name]) ? $primary_display_array['weight'][$machine_name] : 0,
       );
-      $form['islandora_solr_primary_display_array']['configuration'][$machine_name] = array(
+      $form['islandora_solr_primary_display_table']['configuration'][$machine_name] = array(
         '#value' => (isset($profile['configuration']) AND $profile['configuration'] != '') ? l(t('configure'), $profile['configuration']): '',              
       );
     }
     
-    $form['islandora_solr_primary_display_array']['default'] = array(
+    $form['islandora_solr_primary_display_table']['default'] = array(
       '#type' => 'radios',
       '#options' => $options,
       '#default_value' => variable_get('islandora_solr_primary_display', 'default'),
     );
-    $form['islandora_solr_primary_display_array']['enabled'] = array(
+    $form['islandora_solr_primary_display_table']['enabled'] = array(
       '#type' => 'checkboxes',
       '#options' => $options,
       '#default_value' => (!empty($primary_display_array)) ? $primary_display_array['enabled'] : $primary_display_array, // $primary_display_array['enabled'][$machine_name]
@@ -326,22 +326,22 @@ function theme_islandora_solr_search_admin_settings($form){
   $default = variable_get('islandora_solr_primary_display', 'default');
   $rows = array();
  
-  foreach ($form['islandora_solr_primary_display_array']['machine_name'] as $key => $element) {
+  foreach ($form['islandora_solr_primary_display_table']['machine_name'] as $key => $element) {
     $row = array();
     // check if $key is really the array we need. we shouldn't select the #parent array for example.
     if (is_array($element) && element_child($key)) {
  
       if ($key == $default) {
-        $form['islandora_solr_primary_display_array']['enabled'][$key]['#attributes']['disabled'] = 'disabled';
-        $form['islandora_solr_primary_display_array']['enabled'][$key]['#value'] = TRUE;
+        $form['islandora_solr_primary_display_table']['enabled'][$key]['#attributes']['disabled'] = 'disabled';
+        $form['islandora_solr_primary_display_table']['enabled'][$key]['#value'] = TRUE;
       }
       
-      $row[] = array('data' => drupal_render($form['islandora_solr_primary_display_array']['default'][$key]));
-      $row[] = array('data' => drupal_render($form['islandora_solr_primary_display_array']['enabled'][$key]));
-      $row[] = array('data' => drupal_render($form['islandora_solr_primary_display_array']['name'][$key]));
-      $row[] = array('data' => drupal_render($form['islandora_solr_primary_display_array']['machine_name'][$key]));
-      $row[] = array('data' => drupal_render($form['islandora_solr_primary_display_array']['weight'][$key]));
-      $row[] = array('data' => drupal_render($form['islandora_solr_primary_display_array']['configuration'][$key]));
+      $row[] = array('data' => drupal_render($form['islandora_solr_primary_display_table']['default'][$key]));
+      $row[] = array('data' => drupal_render($form['islandora_solr_primary_display_table']['enabled'][$key]));
+      $row[] = array('data' => drupal_render($form['islandora_solr_primary_display_table']['name'][$key]));
+      $row[] = array('data' => drupal_render($form['islandora_solr_primary_display_table']['machine_name'][$key]));
+      $row[] = array('data' => drupal_render($form['islandora_solr_primary_display_table']['weight'][$key]));
+      $row[] = array('data' => drupal_render($form['islandora_solr_primary_display_table']['configuration'][$key]));
  
       $rows[] = $row;
     }
@@ -358,10 +358,10 @@ function theme_islandora_solr_search_admin_settings($form){
   $header[] = t('Configuration');
   
   // put the rendered table in another fieldset.
-  $form['islandora_solr_primary_display_array']['#type'] = 'item';
-  $form['islandora_solr_primary_display_array']['#title'] = t('Primary Display Profile');
-  $form['islandora_solr_primary_display_array']['#description'] = t('Preferred normal display profile for search results.  These may be provided by third-party modules.');
-  $form['islandora_solr_primary_display_array']['#value'] = theme('table', $header, $rows);
+  $form['islandora_solr_primary_display_table']['#type'] = 'item';
+  $form['islandora_solr_primary_display_table']['#title'] = t('Primary Display Profile');
+  $form['islandora_solr_primary_display_table']['#description'] = t('Preferred normal display profile for search results.  These may be provided by third-party modules.');
+  $form['islandora_solr_primary_display_table']['#value'] = theme('table', $header, $rows);
 
   //dsm($form);
   
@@ -490,10 +490,10 @@ function solr_settings_form_submit($form, &$form_state) {
   // old_default variable
   $old_default = variable_get('islandora_solr_primary_display', 'default');
   // new_default variable
-  $new_default = $form_state['values']['islandora_solr_primary_display_array']['default'];
+  $new_default = $form_state['values']['islandora_solr_primary_display_table']['default'];
   // make default enabled
-  $form_state['values']['islandora_solr_primary_display_array']['enabled'][$new_default] = $new_default;
-  $form_state['values']['islandora_solr_primary_display_array']['enabled'][$old_default] = $old_default;
+  $form_state['values']['islandora_solr_primary_display_table']['enabled'][$new_default] = $new_default;
+  $form_state['values']['islandora_solr_primary_display_table']['enabled'][$old_default] = $old_default;
   variable_set('islandora_solr_primary_display', $new_default);
   
   if ($form_state['clicked_button']['#id'] != 'edit-submit') {

--- a/islandora_solr_search.install
+++ b/islandora_solr_search.install
@@ -61,7 +61,7 @@ function islandora_solr_search_uninstall() {
   // @TODO: update the latest additions
   $variables = array(
     'islandora_solr_primary_display',
-    'islandora_solr_primary_display_array',
+    'islandora_solr_primary_display_table',
     'islandora_solr_secondary_display',
     'islandora_solr_searchterms',
     'islandora_solr_search_block_facets',

--- a/islandora_solr_search.install
+++ b/islandora_solr_search.install
@@ -39,3 +39,47 @@ function islandora_solr_search_requirements($phase) {
   return $requirements;
 }
 
+
+/**
+* @file
+* Implementation of hook_install
+*/
+ 
+function islandora_solr_search_install() {
+  
+  $message = t("Islandora Solr Search <a href ='!link'>configuration page</a>.", array('!link' => '/admin/settings/islandora_solr_search'));
+  drupal_set_message($message);
+}
+
+/**
+* Implementation of hook_uninstall
+*/
+ 
+function islandora_solr_search_uninstall() {
+
+  drupal_uninstall_schema('islandora_solr_search');
+  
+  // removing variables
+  $variables = array(
+    'islandora_solr_primary_display',
+    'islandora_solr_secondary_display',
+    'islandora_solr_searchterms',
+    'islandora_solr_search_block_facets',
+    'islandora_solr_search_block_facet_limit',
+    'islandora_solr_search_block_facet_min_count',
+    'islandora_solr_search_block_facet_shown_limit',
+    'islandora_solr_search_block_repeat',
+    'islandora_solr_search_block_request_handler',
+    'islandora_solr_search_block_url',
+    'islandora_solr_search_debug_mode',
+    'islandora_solr_search_limit_result_fields',
+    'islandora_solr_search_num_of_results',
+    'islandora_solr_search_result_fields',
+    'islandora_solr_search_sort_field',
+    'islandora_solr_search_sort_order',
+    'islandora_solr_snippet_field',
+  );
+  foreach ($variables as $variable) {
+    variable_del($variable);
+  }
+}

--- a/islandora_solr_search.install
+++ b/islandora_solr_search.install
@@ -61,6 +61,7 @@ function islandora_solr_search_uninstall() {
   // @TODO: update the latest additions
   $variables = array(
     'islandora_solr_primary_display',
+    'islandora_solr_primary_display_array',
     'islandora_solr_secondary_display',
     'islandora_solr_searchterms',
     'islandora_solr_search_block_facets',

--- a/islandora_solr_search.install
+++ b/islandora_solr_search.install
@@ -56,10 +56,9 @@ function islandora_solr_search_install() {
 */
  
 function islandora_solr_search_uninstall() {
-
-  drupal_uninstall_schema('islandora_solr_search');
   
   // removing variables
+  // @TODO: update the latest additions
   $variables = array(
     'islandora_solr_primary_display',
     'islandora_solr_secondary_display',

--- a/islandora_solr_search.module
+++ b/islandora_solr_search.module
@@ -322,7 +322,26 @@ function islandora_solr_search($query, $fq=NULL, $dismax=NULL) {
   // Order: First choice is what's in the ?profile query var
   //        Second choice is the primary display profile
   //        Third choice is the default IslandoraSolrResults
-  $islandora_solr_primary_display = ((isset($_GET['display']) AND array_key_exists($_GET['display'], $primary_profiles)) ? $_GET['display'] : variable_get('islandora_solr_primary_display', 'default'));
+  
+    
+  $enabled_profiles = array();
+  // get enabled displays
+  $primary_display_array = variable_get('islandora_solr_primary_display_array', array());
+  // if it's set, we take these values
+  if(isset($primary_display_array['enabled'])) {
+    foreach($primary_display_array['enabled'] as $key => $value) {
+      if($key === $value) {
+        $enabled_profiles[] = $key;
+      }
+    }
+  }
+  // if not, we use the default
+  else {
+    $enabled_profiles = array(variable_get('islandora_solr_primary_display', 'default'));
+  }
+
+  // set primary display
+  $islandora_solr_primary_display = ((isset($_GET['display']) AND in_array($_GET['display'], $enabled_profiles)) ? $_GET['display'] : variable_get('islandora_solr_primary_display', 'default'));
   $islandora_solr_selected_display = isset($_GET['solr_profile']) ? $_GET['solr_profile'] : NULL;
 
   // set global variable

--- a/islandora_solr_search.module
+++ b/islandora_solr_search.module
@@ -326,7 +326,7 @@ function islandora_solr_search($query, $fq=NULL, $dismax=NULL) {
     
   $enabled_profiles = array();
   // get enabled displays
-  $primary_display_array = variable_get('islandora_solr_primary_display_array', array());
+  $primary_display_array = variable_get('islandora_solr_primary_display_table', array());
   // if it's set, we take these values
   if(isset($primary_display_array['enabled'])) {
     foreach($primary_display_array['enabled'] as $key => $value) {

--- a/islandora_solr_search.module
+++ b/islandora_solr_search.module
@@ -124,11 +124,20 @@ function islandora_solr_search_block($op = 'list', $delta = 0, $edit = array()) 
  * Implementation of hook_theme().
  */
 function islandora_solr_search_theme() {
+  // set path
+  $path = drupal_get_path('module', 'islandora_solr_search');
+  
   return array(
     'islandora_solr_search_block_form' => array(
       'arguments' => array(
         'form' => NULL,
       ),
+    ),
+    // theme admin form
+    'islandora_solr_search_admin_settings' => array(
+      'path' => $path,
+      'file' => 'islandora_solr_search.admin.inc',
+      'arguments' => array('form' => NULL),
     ),
   );
 }
@@ -145,6 +154,7 @@ function islandora_solr_search_islandora_solr_primary_display() {
     //   'class' => 'ClassName',
     //   'function' => 'function_name',
     //   'description' => 'A description of the display profile',
+    //   'configuration' => 'path/to/configuration/page',
     // );
     //
     // Note: this class should either be, or extend, the class IslandoraSolrResults.


### PR DESCRIPTION
Had some issues with pushing my latest commits up.

In my previous pull request I created the ability to switch primary display profiles by adding ?display=myprofile in the url. Now I recreated the admin interface so that not only you can select a default display, you can also choose which ones to enable to restrict access. I also added weight dropdowns to the table to order the displays. This will be useful when in the next step I'm going to create a block with the links to enabled displays. The order of the links will be based on the weight.

I also added the ability to add a config link to the primary display hook using: 'configuration' => 'path/to/configuration/page',
I added this to the islandora_solr_custom module and I will add it later to the islandora_solr_gmap module: https://github.com/DannyJoris/islandora_solr_custom/commit/e211754cc2e652f4b91a1273b17fa19b0aa0c00b

Here's a screenshot: https://skitch.com/dannyjoris/g4u1f/islandora-solr-client-d6theming
