### PR TITLE
Suggestion: Background filters

### DIFF
--- a/IslandoraSolrQueryProcessor.inc
+++ b/IslandoraSolrQueryProcessor.inc
@@ -22,6 +22,7 @@ class IslandoraSolrQueryProcessor {
   static $slashReplacement = '~slsh~'; // a pattern used to replace / in url's the slash breaks drupal clean url's
   public static $SEARCH_CLASS_ADVANCED_SEARCH_NUMBER_FIELDS = 5;
   public $solrQuery;
+  public $internalSolrQuery;
   public $solrParams;
   public $solrStart;
   public $solrLimit;
@@ -98,10 +99,10 @@ class IslandoraSolrQueryProcessor {
 
     // -- end cut here --
     //fix the query as some characters will break the search : and / slash are examples
-    $this->solrQuery = restoreSlashes($query);
+    $this->solrQuery = urldecode(restoreSlashes($query));
 
-    if (empty($this->solrQuery)) {
-      // $this->solrQuery = '%20'; //so we can allow empty queries to dismax
+    if (empty($this->solrQuery) || in_array($this->solrQuery,$this->different_kinds_of_nothing)) {
+      $this->solrQuery = ' '; //so we can allow empty queries to dismax
     }
 
     $facetArray = array();
@@ -136,12 +137,17 @@ class IslandoraSolrQueryProcessor {
     }
     $debugQuery = (variable_get('islandora_solr_search_debug_mode', 0) ? "TRUE" : NULL ); //any val incl. 'FALSE' is treated as TRUE by Solr
 
+    $base_filters = preg_split("/\\r\\n|\\n|\\r/", variable_get('islandora_solr_search_base_filter', ''), -1, PREG_SPLIT_NO_EMPTY);
+
     if ($fq != NULL && $fq != '-') {
       $fq = restoreSlashes($fq); //put the slash back
 
       $fqs = csv_explode(IslandoraSolrQueryProcessor::$facetSeparator, $fq, '"', TRUE); //to filter by more then one facet we will separate them by~ for nowseparate them by~ for now
+      $fqs = array_merge($fqs,$base_filters);
       $this->solrParams['fq'] = $fqs;
       $islandora_fq = replaceSlashes($fq); //remove the slash here as we will be using this in url's
+    } elseif (!empty($base_filters)) {
+      $this->solrParams['fq'] = $base_filters;
     }
     if (empty($islandora_fq)) {
       $islandora_fq = '-';
@@ -153,7 +159,7 @@ class IslandoraSolrQueryProcessor {
     $this->solrStart = max(0, $startPage) * $this->solrLimit;
 
     // The breadcrumb should go in the display class
-    $queryurl = "islandora/solr/search/" . replaceSlashes($this->solrQuery);
+    $queryurl = SOLR_SEARCH_PATH . "/" . replaceSlashes($this->solrQuery);
     $breadcrumb_fq = $islandora_fq;
     $facet = NULL; // Nigelb, This is being used outside of the for loop where it is being created this is probably incorrect.
     if (strcmp($islandora_fq, "-")) {
@@ -173,8 +179,8 @@ class IslandoraSolrQueryProcessor {
         $breadcrumb_fq = $this->delete_filter($breadcrumb_fq, $facet);
       }
     }
-    if (!empty($this->solrQuery) && strcmp($this->solrQuery, ' ')) {
-      $cutlink = "islandora/solr/search/ /$islandora_fq/dismax/$display_param";
+    if (!in_array($this->solrQuery,$this->different_kinds_of_nothing)) {
+      $cutlink = SOLR_SEARCH_PATH . "/ /" . $islandora_fq . '/-/' . $display_param;
       $queryval = $this->solrQuery;
       $tokens = explode(' ', $queryval);
       foreach ($tokens as $token) {
@@ -195,11 +201,24 @@ class IslandoraSolrQueryProcessor {
     drupal_set_breadcrumb($breadcrumb);
     $this->solrFilters = $islandora_fq;
 
+    $this->internalSolrQuery = $this->solrQuery;
+
+    // replace the various null queries with a sensible catch-all.
+    if(in_array($this->internalSolrQuery,$this->different_kinds_of_nothing)) {
+      $this->internalSolrQuery = variable_get('islandora_solr_search_base_query', SOLR_BASE_QUERY);
+      // we must also undo dismax if it's been set
+      $this->solrDefType = null;
+      $this->solrParams['defType'] = null;
+    } else {
+      // append the catch-all query to any queries which lack it?
+      // No, not under normal circumstances, and it would break dismax.
+    }
     // restrict results based on specified namespace
-    $namespace = variable_get('solr_namespace_restriction', 'null');
+    $namespace = trim(variable_get('solr_namespace_restriction', NULL));
     if ($namespace) {
       $this->solrParams['fq'][] = "PID:$namespace\:*";
     }
+
 
     // if no qf fields are specified in rthe requestHandler a default list is supplied here for dismax searches
     if (!variable_get('dismax_allowed', 0) && $dismax == "dismax") {
@@ -243,7 +262,7 @@ class IslandoraSolrQueryProcessor {
 
     // This is where the query gets executed and output starts being created.
     try {
-      $results = $solr->search($this->solrQuery, $this->solrStart, $this->solrLimit, $this->solrParams);
+      $results = $solr->search($this->internalSolrQuery, $this->solrStart, $this->solrLimit, $this->solrParams);
     } catch (Exception $e) {
       drupal_set_message(check_plain(t('error searching')) . ' ' . $e->getMessage());
     }

--- a/IslandoraSolrQueryProcessor.inc
+++ b/IslandoraSolrQueryProcessor.inc
@@ -124,7 +124,7 @@ class IslandoraSolrQueryProcessor {
       'facet.mincount' => $facetMinCount,
       'facet.limit' => $facetlimit,
       'qt' => $requestHandler,
-      'hl' => 'true',
+      'hl' => isset($keys[0]) ? 'true' : NULL,
       'hl.fl' => isset($keys[0]) ? trim($keys[0]) : NULL,
       'hl.fragsize' => 400,
       'facet.field' => explode(',', $facetFields), //comma separated list configured in the block config

--- a/IslandoraSolrQueryProcessor.inc
+++ b/IslandoraSolrQueryProcessor.inc
@@ -6,6 +6,9 @@
  * Depends on Apache_Solr_Php client.
  */
 
+DEFINE('SOLR_SEARCH_PATH','islandora/solr/search');
+DEFINE('SOLR_BASE_QUERY','timestamp:[* TO NOW]');
+
 /**
  * Islandora Solr Query Processor
  * @todo Stop using global vars, start using this object's vars.
@@ -25,6 +28,8 @@ class IslandoraSolrQueryProcessor {
   public $solrDefType;
   public $solrFilters;
   public $solrResult;
+
+  public $different_kinds_of_nothing = array( ' ', '%20', '%252F', '%2F', '%252F-', '' );
 
   /**
    * Constructor

--- a/islandora_solr_search.admin.inc
+++ b/islandora_solr_search.admin.inc
@@ -299,6 +299,24 @@ function islandora_solr_admin_settings(&$form_state) {
     '#description' => t('The number of results to show per page.'),
     '#default_value' => variable_get('islandora_solr_search_num_of_results', '20'),
   );
+  $form['islandora_solr_search_base_query'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Solr Default Query'),
+    '#size' => 30,
+    '#description' => t('A default query to use to browse solr results when no explicit user query is set.
+      Setting a useful default query allows users to use solr to browse, without entering a query themselves.
+      May be used in conjunction with a background filter, below.<br>
+      Consider <strong><em>timestamp:[* TO NOW]</em></strong> or <strong><em>*:*</em></strong><br/>'),
+    '#default_value' => variable_get('islandora_solr_search_base_query', 'timestamp:[* TO NOW]'),
+  );
+  $form['islandora_solr_search_base_filter'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Solr Base Filter'),
+    '#description' => t('Some base filters to append to all user queries -- may be used to filter results and to facilitate null-query browsing. Enter one per line. <br/>
+      These filters will be applied to all queries in addition to any user-selected facet filters'),
+    '#default_value' => variable_get('islandora_solr_search_base_filter', ''),
+    '#wysiwyg' => FALSE,
+  );
   $form['islandora_solr_search_debug_mode'] = array(
     '#type' => 'checkbox',
     '#title' => t('Debug Mode?'),

--- a/islandora_solr_search.admin.inc
+++ b/islandora_solr_search.admin.inc
@@ -236,6 +236,7 @@ function islandora_solr_admin_settings(&$form_state) {
     '#default_value' => variable_get('islandora_solr_snippet_field', ''),
     '#description' => t("If a match is found on this field, a snippet of text will be returned, with the search term highlighted.<br />
       An optional friendly label may inserted using the following pattern <strong>dsm.Text ~ Full Text</strong><br />
+      Use an asterisk (<strong>*</strong>) for all fields, leave blank to disable highlighting.<br />
       <strong>Note:</strong><em> This feature is not supported by all display profiles.</em> "),
     '#wysiwyg' => FALSE,
   );


### PR DESCRIPTION
This change enables the use of islandora_solr_search without any user-specified query, i.e. in browse-only mode.  It allows a configurable default query (q) that is sent to solr in lieu of a user-supplied one.  

Notably, users can use the breadcrumb when browsing results in islandora_solr_search, and can back up and delete specific filters (fq elements), and for some time they've been able to delete the _base query_, but this fails (always leads to no search results found).  With this change, seamless filter-only browsing is made possible.  

Additionally this allows the configuration of additional arbitrary query filters to be applied in addition to any user-generated filters, similar to what's done with the namespace restriction, but generalized. It can be useful to globally filter out results of types that are not desirable.
