### PR TITLE
Added check to load SolrPhpClient from the apachesolr module

### DIFF
--- a/IslandoraSolrQueryProcessor.inc
+++ b/IslandoraSolrQueryProcessor.inc
@@ -36,7 +36,12 @@ class IslandoraSolrQueryProcessor {
    * Constructor
    */
   function IslandoraSolrQueryProcessor() {
-    module_load_include('php', 'islandora_solr_search', 'SolrPhpClient/Apache/Solr/Service');
+    if (module_exists('apachesolr')) {
+      module_load_include('php', 'apachesolr', 'SolrPhpClient/Apache/Solr/Service');
+    }
+    else {
+      module_load_include('php', 'islandora_solr_search', 'SolrPhpClient/Apache/Solr/Service');
+    }
     module_load_include('inc', 'islandora_solr_search', 'includes/common');
   }
 

--- a/IslandoraSolrResults.inc
+++ b/IslandoraSolrResults.inc
@@ -22,7 +22,12 @@ class IslandoraSolrResults {
    * Constructor
    */
   function IslandoraSolrResults() {
-    module_load_include('php', 'islandora_solr_search', 'SolrPhpClient/Apache/Solr/Service');
+    if (module_exists('apachesolr')) {
+      module_load_include('php', 'apachesolr', 'SolrPhpClient/Apache/Solr/Service');
+    }
+    else {
+      module_load_include('php', 'islandora_solr_search', 'SolrPhpClient/Apache/Solr/Service');
+    }
     module_load_include('inc', 'islandora_solr_search', 'includes/common');
     $this->prepFieldSubstitutions();
   }

--- a/islandora_solr_config/IslandoraSolrResultsCSV.inc
+++ b/islandora_solr_config/IslandoraSolrResultsCSV.inc
@@ -15,7 +15,12 @@ module_load_include('inc', 'islandora_solr_search', 'IslandoraSolrResults');
 class IslandoraSolrResultsCSV extends IslandoraSolrResults {
 
   function IslandoraSolrResultsCSV() {
-    module_load_include('php', 'islandora_solr_search', 'SolrPhpClient/Apache/Solr/Service');
+    if (module_exists('apachesolr')) {
+      module_load_include('php', 'apachesolr', 'SolrPhpClient/Apache/Solr/Service');
+    }
+    else {
+      module_load_include('php', 'islandora_solr_search', 'SolrPhpClient/Apache/Solr/Service');
+    }
   }
 
   /**

--- a/islandora_solr_search.admin.inc
+++ b/islandora_solr_search.admin.inc
@@ -332,7 +332,7 @@ function islandora_solr_admin_settings(&$form_state) {
     '#title' => t('Debug Mode?'),
     '#return_value' => 1,
     '#default_value' => variable_get('islandora_solr_search_debug_mode', 0),
-    '#description' => t('Dumps solr query to the screen for testing'),
+    '#description' => t('Dumps solr query to the screen for testing. Warning: if you have the Drupal Apache Solr module enabled alongside this one then the debug function will not work.'),
   );
 
   $form['buttons']['submit'] = array(

--- a/islandora_solr_search.admin.inc
+++ b/islandora_solr_search.admin.inc
@@ -14,8 +14,13 @@
 function islandora_solr_admin_settings(&$form_state) {
 
   //checks for existence of PHP Solr client.
-  module_load_include('php', 'islandora_solr_search', 'SolrPhpClient/Apache/Solr/Service');
-  if (!class_exists('Apache_Solr_Service')) {
+    if (module_exists('apachesolr')) {
+      module_load_include('php', 'apachesolr', 'SolrPhpClient/Apache/Solr/Service');
+    }
+    else {
+      module_load_include('php', 'islandora_solr_search', 'SolrPhpClient/Apache/Solr/Service');
+    }
+    if (!class_exists('Apache_Solr_Service')) {
     $message = t('This module requires the !url. Please install the client directory in the root directory of this module before continuing.', array('!url' => l(t('Apache Solr php client'), 'http://code.google.com/p/solr-php-client')));
     drupal_set_message(check_plain($message));
     return;

--- a/islandora_solr_search.install
+++ b/islandora_solr_search.install
@@ -29,8 +29,13 @@
 function islandora_solr_search_requirements($phase) {
   $t = get_t();
   $requirements = array();
-  module_load_include('php', 'islandora_solr_search', 'SolrPhpClient/Apache/Solr/Service');
-  if ($phase == 'install') {
+    if (module_exists('apachesolr')) {
+      module_load_include('php', 'apachesolr', 'SolrPhpClient/Apache/Solr/Service');
+    }
+    else {
+      module_load_include('php', 'islandora_solr_search', 'SolrPhpClient/Apache/Solr/Service');
+    }
+    if ($phase == 'install') {
 
 
     if (!class_exists('Apache_Solr_Service')) {


### PR DESCRIPTION
If the apachesolr module is installed then the islandora_solr_search module will use the SolrPhpClient from this. This allows both modules to be installed and enabled side-by-side and lets drupal and fedora share the same solr index.
In order for this to work the islandora_solr module has to be disabled before the apachesolr module is enabled. Once the apachesolr module is enabled the islandora_solr module can be enabled. Ideally this would be dealt with by storing the SolrPhpClient in the libraries directory.
