### PR TITLE
Fixed a couple of issues 

### DIFF
--- a/IslandoraSolrQueryProcessor.inc
+++ b/IslandoraSolrQueryProcessor.inc
@@ -199,10 +199,15 @@ class IslandoraSolrQueryProcessor {
     }
 
 
-    // restrict results based on specified namespace
-    $namespace = trim(variable_get('islandora_solr_namespace_restriction', ''));
-    if ($namespace) {
-      $this->solrParams['fq'][] = "PID:$namespace\:*";
+    // restrict results based on specified namespaces
+    $namespace_list = trim(variable_get('islandora_solr_namespace_restriction', ''));
+    if ($namespace_list) {
+      $namespaces = preg_split('/[,|\s]/', $namespace_list);
+      $namespace_array = array();
+      foreach (array_filter($namespaces) as $namespace) {
+        $namespace_array[] = "PID:$namespace\:*";
+      }
+      $this->solrParams['fq'][] = implode(' OR ', $namespace_array);
     }
 
     // if no qf fields are specified in the requestHandler a default list is supplied here for dismax searches

--- a/includes/common.inc
+++ b/includes/common.inc
@@ -7,7 +7,6 @@
 
 $values = array("/", "+");
 
-
 /**
  * Initialize a pager for theme('pager') without running an SQL query.
  *
@@ -36,7 +35,7 @@ function islandora_solr_pager_init($total, $limit = 10, $element = 0) {
   // We calculate the total of pages as ceil(items / limit).
   $pager_total_items[$element] = $total;
   $pager_total[$element] = ceil($pager_total_items[$element] / $limit);
-  $pager_page_array[$element] = max(0, min((int)$pager_page_array[$element], ((int)$pager_total[$element]) - 1));
+  $pager_page_array[$element] = max(0, min((int) $pager_page_array[$element], ((int) $pager_total[$element]) - 1));
 
   // return the current position
   return $pager_page_array[$element];
@@ -65,7 +64,6 @@ function replace_slashes($str) {
   $values = array("/", "+");
   return str_replace($values, $replacements, $str); // reverse of above
 }
-
 
 /**
  * A better explode method allows quotes in the returned strings. Taken from
@@ -107,7 +105,7 @@ function lesser_escape($value) {
   // Zac removed the quotation mark and whitespace from this list.
   // a) Spaces in our search strings don't need escaping
   // b) We want to allow users to use quotation marks to indicate multi-word phrases
- //  (alan) pulled the asterisk from excaping to allow wild cards
+  //  (alan) pulled the asterisk from excaping to allow wild cards
   $pattern = '/(\+|-|&&|\|\||!|\(|\)|\{|}|\[|]|\^|~|\?|:|\\\)/';
   $replace = '\\\$1';
 
@@ -122,7 +120,6 @@ function solr_escape($facets) {
     $tmp = lesser_escape(trim($tmp));
 
     $return_facets[] = $tmp . drupal_substr($facet, strpos($facet, ':"'), drupal_strlen($facet));
-
   }
   return $return_facets;
 }
@@ -142,8 +139,10 @@ function islandora_build_substitution_list($raw_field_list) {
     if ($line) {
       $line_array = explode('~', $line);
       $key = trim($line_array[0]);
-      $value = trim($line_array[1]);
-      if (!$value) {
+      if (count($line_array) > 1) {
+        $value = trim($line_array[1]);
+      }
+      else {
         $value = $key;
       }
       $facet_array[$key] = $value;

--- a/islandora_solr.admin.inc
+++ b/islandora_solr.admin.inc
@@ -404,10 +404,10 @@ function islandora_solr_admin_settings($form, &$form_state) {
   );
   $form['query_defaults']['islandora_solr_namespace_restriction'] = array(
     '#type' => 'textfield',
-    '#title' => t('Limit results to namespace'),
-    '#size' => 5,
+    '#title' => t('Limit results to specific namespaces'),
+    '#size' => 30,
     '#default_value' => variable_get('islandora_solr_namespace_restriction', ''),
-    '#description' => t("Enter a namespace ie 'demo' to restrict results to PIDs within that namespace."),
+    '#description' => t("Enter a space or comma-separated list of namespaces ie 'demo, default' to restrict results to PIDs within those namespaces."),
   );
   $form['query_defaults']['islandora_solr_base_query'] = array(
     '#type' => 'textfield',


### PR DESCRIPTION
The returned fields mapping was displaying an error if there was no alternative given for the field name. For example PID ~ PID worked fine but just having PID caused an error. I fixed this so that, in the absence of a mapping, the label is set as the field name.
I also expanded the namespace restriction to allow multiple namespaces rather than just one. More of the configuration is being moved into the module, away from the solrconfig.xml, and searching over more than one namespace is something that is needed.
