### PR TITLE
6.x making sure certain blocks only show on the search results page

### DIFF
--- a/islandora_solr_search.module
+++ b/islandora_solr_search.module
@@ -442,7 +442,7 @@ function islandora_solr_search_display() {
   $output = '';
   
   // check if the page is dealing with search results
-  if (class_exists('IslandoraSolrResults')) {
+  if (isset($queryClass->display)) {
     
     // parameters set in url
     $params = $queryClass->internalSolrParams;
@@ -530,7 +530,7 @@ function islandora_solr_search_limit() {
   $output = '';
   
   // check if the page is dealing with search results
-  if (class_exists('IslandoraSolrResults')) {
+  if (isset($queryClass->display)) {
     
     // parameters set in url
     $params = $queryClass->internalSolrParams;
@@ -620,7 +620,7 @@ function islandora_solr_search_sort() {
   $output = '';
 
   // check if the page is dealing with search results
-  if (class_exists('IslandoraSolrResults')) {
+  if (isset($queryClass->display)) {
 
     // parameters set in url
     $params = isset($queryClass->internalSolrParams) ? $queryClass->internalSolrParams : array();


### PR DESCRIPTION
making sure certain blocks only show on the search results page - backported from d7, but still not an ideal solution. This solution at least prevents these blocks from showing up and throwing errors when the query block is set before the others. This is because the query block always triggers the resultsClass.
