### PR TITLE
trigger haslayout and conditional hack for inline-block

### DIFF
--- a/css/islandora_solr_search.css
+++ b/css/islandora_solr_search.css
@@ -107,6 +107,8 @@ img.islandora_solr_secondary_display_icon {
   margin: 0;
   padding: 0 6px 0 3px;
   border-right: 1px solid #494949;
+  zoom: 1;
+  *display: inline;
 }
 
 .item-list ul.islandora-solr-search-limit.horizontal li.last


### PR DESCRIPTION
This inline list of items used to limit search results does not have the required fix for IE to trigger haslayout, resulting in a vertical list instead of an inline-list for IE7. 

bug info: 
IE7 only supports inline-block on naturally inline elements, in order to correct this bug, conditional hacks need to be applied for IE7. 

fix: 
zoom: 1 triggers hasLayout behaviour, and a star property hack is needed for display:inline in IE7.
