### PR TITLE
7.x

### DIFF
--- a/css/islandora_solr.theme.css
+++ b/css/islandora_solr.theme.css
@@ -15,9 +15,11 @@
 
 /* Default solr results styling (list) */
 
+
+
 .islandora-solr-search-result
 {
-  float: left;
+  display: inline-block;
   width: 100%;
   margin: 0 0 1.5em 0;
 }

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -403,7 +403,7 @@ function islandora_solr_admin_settings($form, &$form_state) {
     '#title' => t('Limit results to specific namespaces'),
     '#size' => 30,
     '#default_value' => variable_get('islandora_solr_namespace_restriction', ''),
-    '#description' => t("Enter a space or comma-separated list of namespaces ie 'demo, default' to restrict results to PIDs within those namespaces."),
+    '#description' => t("Enter a space or comma-separated list of namespaces i.e. 'demo, default' to restrict results to PIDs within those namespaces."),
   );
   $form['islandora_solr_tabs']['query_defaults']['islandora_solr_base_query'] = array(
     '#type' => 'textfield',
@@ -1380,7 +1380,7 @@ function islandora_solr_admin_settings_result_fields($form, &$form_state, $varia
     '#default_value' => $values['label'],
     '#description' => t('A human readable name.'),
   );
-  
+
   $form['options']['link_to_object'] = array(
     '#type' => 'checkbox',
     '#title' => t('Link to object'),
@@ -1396,9 +1396,9 @@ function islandora_solr_admin_settings_result_fields($form, &$form_state, $varia
   $highlighting_allowed = islandora_solr_check_highlighting_allowed($solr_field);
   if ($highlighting_allowed == FALSE) {
     $form['options']['snippet']['#default_value'] = 0;
-    $form['options']['snippet']['#disabled'] = TRUE;    
+    $form['options']['snippet']['#disabled'] = TRUE;
   }
-  
+
   $form['options']['permissions_fieldset'] = array(
     '#type' => 'fieldset',
     '#title' => t('Permissions'),
@@ -1690,19 +1690,6 @@ function islandora_solr_admin_settings_facet_fields($form, &$form_state, $variab
   );
   return $form;
 }
-
-/**
- * Ajax callback function for range facet checkbox.
- */
-/*
-function _islandora_solr_admin_settings_facet_fields_callback($form, &$form_state) {
-
-  // resize modal
-  ajax_command_invoke(NULL, 'islandoraSolrResizeModal', array());
-
-  return $form['options']['range_facet'];
-}
- */
 
 /**
  * Form for search field settings.

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -1269,6 +1269,7 @@ function _islandora_solr_handle_solr_field_settings($solr_field_settings = NULL,
       case 'result_fields':
         return array(
           'label' => $solr_field_settings['label'],
+          'link_to_object' => $solr_field_settings['link_to_object'],
           'snippet' => $solr_field_settings['snippet'],
           'permissions' => $solr_field_settings['permissions'],
         );
@@ -1380,6 +1381,12 @@ function islandora_solr_admin_settings_result_fields($form, &$form_state, $varia
     '#description' => t('A human readable name.'),
   );
   
+  $form['options']['link_to_object'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Link to object'),
+    '#default_value' => $values['link_to_object'],
+    '#description' => t('Link this field to the object page.'),
+  );
   $form['options']['snippet'] = array(
     '#type' => 'checkbox',
     '#title' => t('Highlight'),

--- a/includes/common.inc
+++ b/includes/common.inc
@@ -1,11 +1,9 @@
 <?php
 
-/*
+/**
  * @file
  * Contains some non-class-specific methods and things I'm not sure where to put.
  */
-
-$values = array("/", "+");
 
 /**
  * Initialize a pager for theme('pager') without running an SQL query.
@@ -112,7 +110,9 @@ function lesser_escape($value) {
   return preg_replace($pattern, $replace, $value);
 }
 
-//escape characters in field names of facets
+/**
+ * Escape characters in field names of facets.
+ */
 function solr_escape($facets) {
   $return_facets = array();
   foreach ($facets as $facet) {
@@ -191,7 +191,7 @@ function islandora_solr_prepare_solr_doc($object_results) {
 }
 
 /**
- * Prepares Solr results before rendering. Applies highlighting, implodes arrays and 
+ * Prepares Solr results before rendering. Applies highlighting, implodes arrays and
  * links to objects to Solr result fields.
  *
  * @param $array $solr_results
@@ -200,7 +200,7 @@ function islandora_solr_prepare_solr_doc($object_results) {
  *   Returns the same array but with prepared Solr field values.
  */
 function islandora_solr_prepare_solr_results($solr_results) {
-  $object_results = $solr_results['response']['objects']; 
+  $object_results = $solr_results['response']['objects'];
   $highlighting = $solr_results['highlighting'];
   $fields_all = islandora_solr_get_fields('result_fields', FALSE);
   $link_to_object = islandora_solr_get_link_to_object_fields();

--- a/includes/common.inc
+++ b/includes/common.inc
@@ -189,3 +189,56 @@ function islandora_solr_prepare_solr_doc($object_results) {
   }
   return $object_results;
 }
+
+/**
+ * Prepares Solr results before rendering. Applies highlighting, implodes arrays and 
+ * links to objects to Solr result fields.
+ *
+ * @param $array $solr_results
+ *  Array containing the Solr results which are altered trough the query processor.
+ * @return array $solr_results
+ *   Returns the same array but with prepared Solr field values.
+ */
+function islandora_solr_prepare_solr_results($solr_results) {
+  $object_results = $solr_results['response']['objects']; 
+  $highlighting = $solr_results['highlighting'];
+  $fields_all = islandora_solr_get_fields('result_fields', FALSE);
+  $link_to_object = islandora_solr_get_link_to_object_fields();
+
+  // Loop over object results.
+  foreach ($object_results as $object_index => $object_result) {
+    $solr_doc = $object_result['solr_doc'];
+    $pid = $object_result['PID'];
+    $rows = array();
+    $options = array('html' => TRUE);
+    if (isset($object_result['object_label'])) {
+      $options['attributes']['title'] = $object_result['object_label'];
+    }
+    if (isset($object_result['object_url_params'])) {
+      $options['query'] = $object_result['object_url_params'];
+    }
+    if (isset($object_result['object_url_fragment'])) {
+      $options['fragment'] = $object_result['object_url_fragment'];
+    }
+
+    foreach ($solr_doc as $field => $value) {
+      // Check highlighting.
+      if (isset($highlighting[$pid][$field])) {
+        $value = $highlighting[$pid][$field];
+      }
+      else {
+        $value = $solr_doc[$field];
+      }
+      // Implode
+      $value = is_array($value) ? implode(", ", $value) : $value;
+      // Add link.
+      if (in_array($field, $link_to_object)) {
+        $value = l($value, $object_result['object_url'], $options);
+      }
+      $solr_doc[$field] = $value;
+    }
+    // Replace Solr doc rows.
+    $solr_results['response']['objects'][$object_index]['solr_doc'] = $solr_doc;
+  }
+  return $solr_results;
+}

--- a/includes/db.inc
+++ b/includes/db.inc
@@ -139,6 +139,20 @@ function islandora_solr_get_snippet_fields() {
 }
 
 /**
+ * Return display fields with 'link to object' enabled.
+ */
+function islandora_solr_get_link_to_object_fields() {
+  $records = islandora_solr_get_fields('result_fields', TRUE, FALSE);
+  $link_to_object_fields = array();
+  foreach ($records as $key => $value) {
+    if (isset($value['solr_field_settings']['link_to_object']) && $value['solr_field_settings']['link_to_object'] == 1) {
+      $link_to_object_fields[] = $value['solr_field'];
+    }
+  }
+  return $link_to_object_fields;
+}
+
+/**
  * Return facet fields with range enabled.
  */
 function islandora_solr_get_range_facets() {

--- a/includes/db.inc
+++ b/includes/db.inc
@@ -34,7 +34,7 @@ function islandora_solr_get_fields($field_type = NULL, $filter = TRUE, $simplifi
   }
   catch (Exception $e) {
     if ($e->errorInfo[0] == '42S02') {
-      drupal_set_message(t('Islandora solr fields table not found. Try running <a href="!update_url">update.php</a>.', array('!update_url' => $base_path . 'update.php')), 'error');
+      drupal_set_message(t('Islandora solr fields table not found. Try running <a href="@update_url">update.php</a>.', array('@update_url' => url('update.php'))), 'error');
     }
     else {
       drupal_set_message($e->getMessage(), 'error');
@@ -53,12 +53,12 @@ function islandora_solr_get_fields($field_type = NULL, $filter = TRUE, $simplifi
   if ($simplified == TRUE) {
     $records = _islandora_solr_simplify_fields($records);
   }
-  // fields as keys  
+  // fields as keys
   if ($keys == TRUE && $simplified == FALSE) {
     foreach ($records as $key => $value) {
       $records[$value['solr_field']] = $value;
       unset($records[$key]);
-    }    
+    }
   }
   return $records;
 }

--- a/includes/facets.inc
+++ b/includes/facets.inc
@@ -36,7 +36,7 @@ function islandora_solr_forms($form_id, $args) {
 function islandora_solr_date_filter_form($form, &$form_state, $elements) {
   global $_islandora_solr_queryclass;
   extract($elements);
-  
+
   $form = array(
     '#tree' => TRUE,
     '#prefix' => '<div class="islandora-solr-date-filter">',
@@ -82,7 +82,7 @@ function islandora_solr_date_filter_form($form, &$form_state, $elements) {
             $from_default = NULL;
           }
           if ($to_unix !== FALSE) {
-            $to_default = (strpos($filter_array[1], '*') !== FALSE) ? '*' : format_date($to_unix, 'custom', $format, 'UTC');            
+            $to_default = (strpos($filter_array[1], '*') !== FALSE) ? '*' : format_date($to_unix, 'custom', $format, 'UTC');
           }
           else {
             $to_default = NULL;
@@ -151,7 +151,7 @@ function islandora_solr_date_filter_form($form, &$form_state, $elements) {
   $form['#submit'][] = 'islandora_solr_date_filter_form_submit';
   // Validate
   $form['#validate'][] = 'islandora_solr_date_filter_form_validate';
-    
+
   // include datepicker js
   drupal_add_library('system', 'ui.datepicker');
   // add datepicker css
@@ -308,7 +308,7 @@ function islandora_solr_range_slider_form($form, &$form_state, $elements) {
     'gap' => $gap,
     'range_from' => format_date(strtotime(trim($from_default['date'])) + 1, 'custom', $date_format, 'UTC'),
     'range_to' => format_date(strtotime(trim($to_default['date'])), 'custom', $date_format, 'UTC'),
-  );  
+  );
   $form['markup'] = array(
     '#markup' => theme('islandora_solr_range_slider', $slider_variables),
   );
@@ -338,7 +338,7 @@ function islandora_solr_range_slider_form($form, &$form_state, $elements) {
   // include flot
   // @TODO: use the libraries module for this!
   // @TODO: use the new version of flot. Didn't work out of the box, so needs some extra attention.
-  drupal_add_js(drupal_get_path('module', 'islandora_solr') . '/js/flot/jquery.flot.min.js');  
+  drupal_add_js(drupal_get_path('module', 'islandora_solr') . '/js/flot/jquery.flot.min.js');
   // @TODO: find a good way to call this for IE8 and lower
   // <!--[if lte IE 8]><![endif]-->
 //  drupal_add_js(drupal_get_path('module', 'islandora_solr') . '/js/flot/excanvas.min.js');

--- a/includes/query_processor.inc
+++ b/includes/query_processor.inc
@@ -321,7 +321,7 @@ class IslandoraSolrQueryProcessor {
           // Hook to alter everything.
           drupal_alter('islandora_solr_results', $object_results, $this);
           // Additional Solr doc preparation. Includes field permissions and limitations.
-          $object_results = $this->prepareSolrDoc($object_results, $solr_results['highlighting']);
+          $object_results = $this->prepareSolrDoc($object_results);
         }
       }
       // Save results tailored for Islandora's use.
@@ -336,17 +336,15 @@ class IslandoraSolrQueryProcessor {
   }
 
   /**
-   * Iterates of the Solr doc of every result object and applies filters,
-   * sort orders and highlighting.
+   * Iterates of the Solr doc of every result object and applies permission filters
+   * and sort orders.
    *
    * @param array $object_results
    *   An array containing the prepared object results.
-   * @param array $highlighting
-   *   Contains the highlighting array from the Solr results.
    * @return array
    *   The object results array with updated solr doc values.
    */
-  function prepareSolrDoc($object_results, $highlighting = array()) {
+  function prepareSolrDoc($object_results) {
     // optionally limit results to values given
     $limit_results = variable_get('islandora_solr_limit_result_fields', 0);
     // look for fields with no permission
@@ -357,19 +355,11 @@ class IslandoraSolrQueryProcessor {
     // Loop over object results.
     foreach ($object_results as $object_index => $object_result) {
       $doc = $object_result['solr_doc'];
-      $pid = $object_result['PID'];
       $rows = array();
       // 1. add defined fields
       foreach ($fields_filtered as $field => $label) {
         if (isset($doc[$field]) && !empty($doc[$field])) {
-          // Check highlighting.
-          if (isset($highlighting[$pid][$field])) {
-            $value = $highlighting[$pid][$field];
-          }
-          else {
-            $value = $doc[$field];
-          }
-          $rows[$field] = is_array($value) ? implode(", ", $value) : $value;
+          $rows[$field] = $doc[$field];
         }
       }
       // 2. if limit isn't set, add other fields
@@ -379,7 +369,7 @@ class IslandoraSolrQueryProcessor {
           if (isset($rows[$field]) || in_array($field, $fields_no_permission)) {
             continue;
           }
-          $rows[$field] = is_array($value) ? implode(", ", $value) : $value;
+          $rows[$field] = $doc[$field];
         }
       }
       // Replace Solr doc rows.

--- a/includes/results.inc
+++ b/includes/results.inc
@@ -145,6 +145,7 @@ class IslandoraSolrResults {
    * @see IslandoraSolrResults::displayResults()
    */
   function printResults($solr_results) {
+    $solr_results = islandora_solr_prepare_solr_results($solr_results);
     $object_results = $solr_results['response']['objects'];
     $object_results = islandora_solr_prepare_solr_doc($object_results);
     $elements = array();

--- a/includes/results.inc
+++ b/includes/results.inc
@@ -901,7 +901,7 @@ class IslandoraSolrFacets {
       if ($count < self::$minimum_count || array_search($filter, $fq) !== FALSE) {
         continue;
       }
-      // current path including query. e.g. islandora/solr/query
+      // current path including query, for example islandora/solr/query
       $path = SOLR_SEARCH_PATH . '/' . replace_slashes($islandoraSolrQuery->solrQuery); // $_GET['q'] didn't seem to work here
       // parameters set in url
       $params = $islandoraSolrQuery->internalSolrParams;

--- a/islandora_solr.install
+++ b/islandora_solr.install
@@ -1,5 +1,6 @@
 <?php
-/*
+
+/**
  * @file
  * islandora_solr install file
  */
@@ -8,7 +9,7 @@
  * Implements hook_requirements().
  *
  * @param type $phase
- * 
+ *
  * @return array
  *   An array describing the status of the site regarding available updates.
  *   If there is no update data, only one record will be returned, indicating

--- a/islandora_solr.module
+++ b/islandora_solr.module
@@ -302,45 +302,6 @@ function islandora_solr($query = NULL) {
 }
 
 /**
- * Implements hook_help().
- *
- * @param type $path
- * @param type $arg
- * @return type
- */
-function islandora_solr_help($path, $arg) {
-  switch ($path) {
-    case 'admin/help#islandora_solr':
-      return t(
-          '<p>
-         The Islandora Solr Search extends the functionality of the Fedora_Repository module.
-         This module allows one or more of a series of blocks to be configured to search a solr index.
-         This module can co-exist with the original Fedora_Repositories search block, but Solr\'s
-         additional functionality will normally make the original block redundant.
-         </p>
-         <p>
-         The !guide contains additonal information.
-         </p>
-         <ul>
-           <li>Islandora Solr Search requires a working Solr instance. The !sWiki has full setup instructions</li>
-           <li>Once Solr is running and tested, configure <b>Gsearch</b> to update Solr. Consult the !GSearch for details.</li>
-           <li>Retreive the !client, unzip it, and copy the <b>Solr</b> directory from the archive to the islandora_solr module\'s folder.</li>
-           <li>Go to Administer &gt; Site Configuration &gt; Islandora Solr Client <em>(or click the link below)</em> to configure the module. Set which Solr request handler to use, set the port, host and context for the index to be queried, and select which fields are to be used for filtering. Solr\'s <b>schema.xml</b> and  <b>solrconfig.xml</b> must be configured for the request handler as well as which  fields to index and return.</li>
-           <li>The module allows custom code to be used to display search results.&nbsp; If custom PHP code is used, the paths to that codes\'s file and function must be entered here as well.</li>
-           <li>Three different blocks are now available under Administer &gt; Site Building &gt; Blocks:&nbsp; Islandora Solr Simple Search Block, Islandora Solr Facet Block, and Islandora Solr Search Block.&nbsp; The configuration setting for each of these blocks will allow you to control their position on the screen, and on which pages they will be displayed.</li>
-           <li>The Islandora Solr Simple Search Block will use will add  defType=dismax to the configured request handler. The request handler tag in <b>solrconfig.xml</b> must have an attribute of <b>default="TRUE"</b>.</li>
-         </ul>
-        ', array(
-        '!guide' => l('Islandora Guide', 'https://wiki.duraspace.org/display/ISLANDORA/Islandora+Guide'),
-        '!sWiki' => l("Solr Wiki", 'http://wiki.apache.org/solr/SolrTomcat'),
-        '!GSearch' => l('GSearch Documentation', 'https://wiki.duraspace.org/display/FCSVCS/Generic+Search+Service+2.2'),
-        '!client' => l('Apache Solr php client', 'http://code.google.com/p/solr-php-client'),
-          )
-      );
-  }
-}
-
-/**
  * Check if the current context is the search results page.
  *
  * @TODO: checking for display might not be the best way to do this. Need to

--- a/islandora_solr_config/includes/csv_results.inc
+++ b/islandora_solr_config/includes/csv_results.inc
@@ -29,7 +29,7 @@ class IslandoraSolrResultsCSV extends IslandoraSolrResults {
     // not the row number of the upper limit document.  That is, if you
     // want results 40-60, you set solrStart=40, solrLimit=20 -- *not*
     // solrStart=40, solrLimit=60.
-    
+
     global $base_url;
     $result_fields = $this->resultFieldArray;
     // First off, update outer limits
@@ -73,13 +73,13 @@ class IslandoraSolrResultsCSV extends IslandoraSolrResults {
       // This loop is just to update the maximum value counts for each field
       // because if any field in the entire resultset has multiple values,
       // we must break the field into multiple iterated fields.
-      
+
 
       $object_results = $response_data['objects'];
       $object_results = islandora_solr_prepare_solr_doc($object_results);
       foreach ($object_results as $object_result) {
 
-      
+
 /*       foreach ($response_data['objects'] as $object_result) { */
         $doc = $object_result['solr_doc'];
         fputs($docfile, addcslashes(serialize($doc), "\n\r\\") . "\n");

--- a/islandora_solr_config/includes/table_results.inc
+++ b/islandora_solr_config/includes/table_results.inc
@@ -25,6 +25,7 @@ class IslandoraSolrResultsTable extends IslandoraSolrResults {
    */
   function printResults($solr_results) {
     drupal_add_css(drupal_get_path('module', 'islandora_solr_config') . '/css/islandora_solr_config.theme.css');
+    $solr_results = islandora_solr_prepare_solr_results($solr_results);
     $object_results = $solr_results['response']['objects'];
     $object_results = islandora_solr_prepare_solr_doc($object_results);
     $record_start = (int) $solr_results['response']['start'];

--- a/islandora_solr_config/includes/table_results.inc
+++ b/islandora_solr_config/includes/table_results.inc
@@ -39,7 +39,7 @@ class IslandoraSolrResultsTable extends IslandoraSolrResults {
       $row = array();
       $doc = $object_result['solr_doc'];
       $row['#'] = l(($key + 1), $object_result['object_url'], array('query' => $object_result['object_url_params']));
-      foreach($fields as $field => $field_label) {
+      foreach ($fields as $field => $field_label) {
         if (isset($doc[$field]['value'])) {
           $value = $doc[$field]['value'];
           // @TODO: this should probably a config option to truncate the value.

--- a/js/islandora_solr.admin.js
+++ b/js/islandora_solr.admin.js
@@ -1,4 +1,7 @@
-/* Script for islandora_solr admin */
+/**
+ * @file
+ * Script for islandora_solr admin.
+ */
 (function ($) {
 
   // function to trigger a form button when clicking on a link element.

--- a/js/islandora_solr_facets.js
+++ b/js/islandora_solr_facets.js
@@ -1,4 +1,7 @@
-/* Javascript file for islandora solr search facets */
+/**
+ * @file
+ * Javascript file for islandora solr search facets
+ */
 
 (function ($) {
 

--- a/theme/islandora-solr-wrapper.tpl.php
+++ b/theme/islandora-solr-wrapper.tpl.php
@@ -23,7 +23,7 @@
   <?php print $secondary_profiles; ?>
   <div id="islandora-solr-result-count"><?php print $islandora_solr_result_count; ?></div>
 </div>
-<div class="islandora-solr-content content">
+<div class="islandora-solr-content">
   <?php print $solr_pager; ?>
   <?php print $results; ?>
   <?php print $solr_debug; ?>

--- a/theme/islandora-solr.tpl.php
+++ b/theme/islandora-solr.tpl.php
@@ -13,79 +13,34 @@
 
 <?php if (empty($results)): ?>
   <p class="no-results"><?php print t('Sorry, but your search returned no results.'); ?></p>
-  <?php else: ?>
+<?php else: ?>
   <div class="islandora islandora-solr-search-results">
-    <?php
-      $row_result = 0;
-      foreach($results as $key => $result):
-    ?>
+    <?php $row_result = 0; ?>
+    <?php foreach($results as $key => $result): ?>
       <!-- Search result -->
       <div class="islandora-solr-search-result clear-block <?php print $row_result % 2 == 0 ? 'odd' : 'even'; ?>">
-        <!-- Thumbnail -->
-        <dl class="solr-thumb">
-          <dt>
-            <?php
-              $image = '<img src="' . url($result['thumbnail_url'], array('query' => $result['thumbnail_url_params'])) . '" />';
-              // Construct options array for l() function call.  Only include
-              // what is needed.  Can accept standard url parameters and a
-              // single anchor tag (fragment) at the end.
-              $options = array(
-                'html' => TRUE,
-              );
-              if (isset($result['object_url_params'])):
-                $options['query'] = $result['object_url_params'];
-              endif;
-              if (isset($result['object_url_fragment'])):
-                $options['fragment'] = $result['object_url_fragment'];
-              endif;
-              // Construct the thumbnail link.
-              print l($image, $result['object_url'], $options);
-            ?>
-          </dt>
-          <dd></dd>
-        </dl>
-        <!-- Metadata -->
-        <dl class="solr-fields islandora-inline-metadata">
-          <?php
-            $row_field = 0;
-            $max_rows = count($results[$row_result]) - 1;
-            foreach($result['solr_doc'] as $key => $value): ?>
-            <dt class="solr-label
-              <?php
-                print $value['class'];
-                print $row_field == 0 ? ' first' : '';
-                print $row_field == $max_rows ? ' last' : '';
-              ?>">
-              <?php print $value['label']; ?>
+        <div class="islandora-solr-search-result-inner">
+          <!-- Thumbnail -->
+          <dl class="solr-thumb">
+            <dt>
+              <?php print $result['thumbnail']; ?>
             </dt>
-            <?php
-              if ($key == 'PID'):
-                // Construct options array for l() function call.  Only include
-                // what is needed.  Can accept standard url parameters and a
-                // single anchor tag (fragment) at the end.
-                $options = array(
-                  'html' => TRUE,
-                );
-                if (isset($result['object_url_params'])):
-                  $options['query'] = $result['object_url_params'];
-                endif;
-                if (isset($result['object_url_fragment'])):
-                  $options['fragment'] = $result['object_url_fragment'];
-                endif;
-                // Construct the PID link.
-                $value['value'] = l($value['value'], $result['object_url'], $options);
-              endif;
-            ?>
-            <dd class="solr-value <?php print $value['class']; ?><?php print $row_field == 0 ? ' first' : ''; ?><?php print $row_field == $max_rows ? ' last' : ''; ?>">
-              <?php print $value['value']; ?>
-            </dd>
-            <?php $row_field++; ?>
-          <?php endforeach; ?>
-        </dl>
+            <dd></dd>
+          </dl>
+          <!-- Metadata -->
+          <dl class="solr-fields islandora-inline-metadata">
+            <?php foreach($result['solr_doc'] as $key => $value): ?>
+              <dt class="solr-label <?php print $value['class']; ?>">
+                <?php print $value['label']; ?>
+              </dt>
+              <dd class="solr-value <?php print $value['class']; ?>">
+                <?php print $value['value']; ?>
+              </dd>
+            <?php endforeach; ?>
+          </dl>
+        </div>
       </div>
-      <?php
-        $row_result++;
-      endforeach;
-      ?>
+    <?php $row_result++; ?>
+    <?php endforeach; ?>
   </div>
 <?php endif; ?>

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -55,6 +55,31 @@ function islandora_solr_preprocess_islandora_solr_wrapper(&$variables) {
 /**
  * Implements hook_preprocess().
  */
+function islandora_solr_preprocess_islandora_solr(&$variables) {
+  $results = $variables['results'];
+  foreach ($results as $key => $result) {
+    // Thumbnail.
+    $path = url($result['thumbnail_url'], array('query' => $result['thumbnail_url_params']));
+    $image = theme('image', array('path' => $path));
+
+    $options = array('html' => TRUE);
+    if (isset($result['object_label'])) {
+      $options['attributes']['title'] = $result['object_label'];
+    }
+    if (isset($result['object_url_params'])) {
+      $options['query'] = $result['object_url_params'];
+    }
+    if (isset($result['object_url_fragment'])) {
+      $options['fragment'] = $result['object_url_fragment'];
+    }
+    // Thumbnail link.
+    $variables['results'][$key]['thumbnail'] =  l($image, $result['object_url'], $options);
+  }
+}
+
+/**
+ * Implements hook_preprocess().
+ */
 function islandora_solr_preprocess_islandora_solr_facet(&$variables) {
   $buckets = $variables['buckets'];
   if ($variables['hidden']) {


### PR DESCRIPTION
moved logic away from template file + added ability to turn Solr result fields into links.
1. moved link creation away from the template file + added ability to add a 'link to object' to any Solr field through the admin settings.
2. moved highlighting and array implodes away from the query processor
3. brought 1 and 2 together in an optional function that's called in the printResults method.
