### PR TITLE
7.x grammar and clarity fixes

### DIFF
--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -1618,8 +1618,8 @@ function islandora_solr_admin_settings_facet_fields($form, &$form_state, $variab
   $form['options']['range_facet']['wrapper']['range_slider']['range_facet_slider_color'] = array(
     '#type' => 'textfield',
     '#title' => t('Slider color'),
-    '#description' => t('The range slider\'s color, formatted as a hex value. Defaults to <font color="!color">#EDC240</font>', array('!color' => '#EDC240')),
-    '#default_value' => $values['range_facet_slider_color'] ? $values['range_facet_slider_color'] : '#EDC240',
+    '#description' => t('The range slider\'s color, formatted as a hex value. Defaults to <span style="color: !color">#edc240</span>', array('!color' => '#edc240')),
+    '#default_value' => $values['range_facet_slider_color'] ? $values['range_facet_slider_color'] : '#edc240',
     '#states' => array(
       'visible' => array(
         ':input[name="range_facet_slider_enabled"]' => array('checked' => TRUE)

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -31,7 +31,7 @@ function islandora_solr_admin_settings($form, &$form_state) {
 
     // Check for the php solr lib class.
     if (!class_exists('Apache_Solr_Service')) {
-      $message = t('This module requires the <a href="!url">Apache Solr php client</a>. Please install the client directory in the root directory of this module before continuing.', array('!url' => 'http://code.google.com/p/solr-php-client'));
+      $message = t('This module requires the <a href="!url">Apache Solr PHP Client</a>. Please install the client in the root directory of this module before continuing.', array('!url' => 'http://code.google.com/p/solr-php-client'));
       drupal_set_message(check_plain($message));
       return;
     }
@@ -52,7 +52,7 @@ function islandora_solr_admin_settings($form, &$form_state) {
     // get confirmation message
     if ($solr_avail) {
       $confirmation_message = '<img src="' . url('misc/watchdog-ok.png') . '"/>'
-          . t('Successfully connected to Solr server at <a href="!islandora_solr_url_checked" target="_blank">!islandora_solr_url</a> <sub>(!ms ms)</sub>', array('!islandora_solr_url_checked' => islandora_solr_check_http($solr_url), '!islandora_solr_url' => $solr_url, '!ms' => number_format($solr_avail, 2)));
+          . t('Successfully connected to Solr server at <a href="!islandora_solr_url_checked" target="_blank">!islandora_solr_url</a>. <sub>(!ms ms)</sub>', array('!islandora_solr_url_checked' => islandora_solr_check_http($solr_url), '!islandora_solr_url' => $solr_url, '!ms' => number_format($solr_avail, 2)));
     }
     else {
       $confirmation_message = '<img src="' . url('misc/watchdog-error.png') . '"/> '
@@ -74,10 +74,10 @@ function islandora_solr_admin_settings($form, &$form_state) {
   // solr url
   $form['solr_ajax_wrapper']['islandora_solr_url'] = array(
     '#type' => 'textfield',
-    '#title' => t('Solr url'),
+    '#title' => t('Solr URL'),
     '#size' => 80,
     '#weight' => -1,
-    '#description' => t('The url of the Solr installation.  Defaults to localhost:8080/solr.'),
+    '#description' => t('The URL of the Solr installation. Defaults to localhost:8080/solr.'),
     '#default_value' => $solr_url,
     '#required' => TRUE,
     '#ajax' => array(
@@ -112,7 +112,7 @@ function islandora_solr_admin_settings($form, &$form_state) {
       '#type' => 'select',
       '#title' => t('Request handler'),
       '#options' => $handlers,
-      '#description' => t('Request handlers as defined by <a href="!url">solrconfig.xml</a>', array('!url' => 'http://wiki.apache.org/solr/SolrConfigXml')),
+      '#description' => t('Request handlers, as defined by <a href="!url">solrconfig.xml</a>.', array('!url' => 'http://wiki.apache.org/solr/SolrConfigXml')),
       '#default_value' => $handler,
       '#ajax' => array(
         'callback' => '_islandora_solr_update_solr_url',
@@ -136,7 +136,7 @@ function islandora_solr_admin_settings($form, &$form_state) {
   $form['display_profiles']['islandora_solr_primary_display_table'] = array(
     '#type' => 'item',
     '#title' => t('Primary display profiles'),
-    '#description' => t('Preferred normal display profile for search results.  These may be provided by third-party modules.'),
+    '#description' => t('Preferred normal display profile for search results. These may be provided by third-party modules.'),
     '#tree' => TRUE, // this attribute is important to return the submitted values in a deeper nested arrays in
     '#theme' => 'islandora_solr_admin_primary_display',
   );
@@ -285,7 +285,7 @@ function islandora_solr_admin_settings($form, &$form_state) {
   $sort_terms = array(
     '#type' => 'item',
     '#title' => t('Sort fields'),
-    '#description' => t('Indicate what fields should appear in the <strong>Islandora sort block</strong>. To sort on relevancy, use the \'score\' field.<br /><strong>Note:</strong> not all fields are sortable. For more info check the <a href="!url">Solr documentation</a>.', array('!url' => 'http://wiki.apache.org/solr/CommonQueryParameters#sort')),
+    '#description' => t('Indicates what fields should appear in the <strong>Islandora sort block</strong>. To sort on relevancy, use the \'score\' field.<br /><strong>Note:</strong> not all fields are sortable. For more information, check the <a href="!url">Solr documentation</a>.', array('!url' => 'http://wiki.apache.org/solr/CommonQueryParameters#sort')),
     '#tree' => TRUE,
     '#prefix' => '<div id="islandora-solr-sort-fields-wrapper">',
     '#suffix' => '</div>',
@@ -313,7 +313,7 @@ function islandora_solr_admin_settings($form, &$form_state) {
   $facet_terms = array(
     '#type' => 'item',
     '#title' => t('Facet fields'),
-    '#description' => t('Indicate what fields should appear in as <strong>facets</strong>.<br /><strong>Note:</strong> it is recommended to use non-tokenized solr fields (full literal strings).'),
+    '#description' => t('Indicate what fields should appear as <strong>facets</strong>.<br /><strong>Note:</strong> it is recommended to use non-tokenized Solr fields (full literal strings).'),
     '#tree' => TRUE,
     '#prefix' => '<div id="islandora-solr-facet-fields-wrapper">',
     '#suffix' => '</div>',
@@ -333,21 +333,21 @@ function islandora_solr_admin_settings($form, &$form_state) {
     '#type' => 'textfield',
     '#title' => t('Minimum limit'),
     '#size' => 5,
-    '#description' => t('Minimum results required to display a facet'),
+    '#description' => t('The minimum number of results required to display a facet'),
     '#default_value' => variable_get('islandora_solr_facet_min_limit', '2'),
   );
   $form['islandora_solr_tabs']['facet_settings']['islandora_solr_facet_soft_limit'] = array(
     '#type' => 'textfield',
     '#title' => t('Soft limit'),
     '#size' => 5,
-    '#description' => t('The number which should be displayed initially. If there are more, then the a "Show more" button will allow the rest up to the value below to be displayed. Use 0 to disable.'),
+    '#description' => t('The number of results which should be displayed initially. If there are more, then the a "Show more" button will allow the rest up to the value below to be displayed. Use 0 to disable.'),
     '#default_value' => variable_get('islandora_solr_facet_soft_limit', '10'),
   );
   $form['islandora_solr_tabs']['facet_settings']['islandora_solr_facet_max_limit'] = array(
     '#type' => 'textfield',
     '#title' => t('Maximum limit'),
     '#size' => 5,
-    '#description' => t('Set the maximum number of terms that should be returned to the user. For example, if there are 100 possible subjects in a faceted result, you may wish to return only the top 10.'),
+    '#description' => t('The maximum number of terms that should be returned to the user. For example, if there are 100 possible subjects in a faceted result you may wish to only return the top 10.'),
     '#default_value' => variable_get('islandora_solr_facet_max_limit', '20'),
   );
 
@@ -363,7 +363,7 @@ function islandora_solr_admin_settings($form, &$form_state) {
   $search_terms = array(
     '#type' => 'item',
     '#title' => t('Search terms'),
-    '#description' => t('Indicate what fields should appear in the dropdown menu of terms for the <strong>Advanced Search Block</strong>.<br /><strong>Note:</strong> It is recommended to use tokenized fields.'),
+    '#description' => t('Indicates what fields should appear in the dropdown menu of terms for the <strong>Advanced Search Block</strong>.<br /><strong>Note:</strong> it is recommended to use tokenized fields.'),
     '#tree' => TRUE,
     '#prefix' => '<div id="islandora-solr-search-fields-wrapper">',
     '#suffix' => '</div>',
@@ -383,11 +383,11 @@ function islandora_solr_admin_settings($form, &$form_state) {
     '#title' => t('Default boolean operator'),
     '#default_value' => variable_get('islandora_solr_search_boolean', 'user'),
     '#options' => array(
-      'user' => t('User configurable'),
+      'user' => t('User-configurable'),
       'AND' => t('AND'),
       'OR' => t('OR')
     ),
-    '#description' => t('Select a default boolean operator for the search query. User configurable exposes a dropdown which gives the user the choice between AND, OR and NOT.'),
+    '#description' => t('Select a default boolean operator for the search query. Selecting "User-configurable" exposes a dropdown menu which gives the user a choice between AND, OR and NOT.'),
   );
 
 
@@ -403,29 +403,29 @@ function islandora_solr_admin_settings($form, &$form_state) {
     '#title' => t('Limit results to specific namespaces'),
     '#size' => 30,
     '#default_value' => variable_get('islandora_solr_namespace_restriction', ''),
-    '#description' => t("Enter a space or comma-separated list of namespaces i.e. 'demo, default' to restrict results to PIDs within those namespaces."),
+    '#description' => t("Enter a space- or comma-separated list of namespaces (e.g. 'demo, default') to restrict results to PIDs within those namespaces."),
   );
   $form['islandora_solr_tabs']['query_defaults']['islandora_solr_base_query'] = array(
     '#type' => 'textfield',
     '#title' => t('Solr default query'),
     '#size' => 30,
-    '#description' => t('A default query to use to browse solr results when no explicit user query is set.
-      Setting a useful default query allows users to use solr to browse, without entering a query themselves.
-      May be used in conjunction with a background filter, below.<br />
-      Consider <strong>timestamp:[* TO NOW]</strong> or <strong>*:*</strong><br />'),
+    '#description' => t('A default query used to browse Solr results when no explicit user query is set.
+      Setting a useful default query allows the use of Solr to browse without having to enter a query.
+      This may be used in conjunction with a background filter below.<br />
+      Consider using <strong>timestamp:[* TO NOW]</strong> or <strong>*:*</strong><br />'),
     '#default_value' => variable_get('islandora_solr_base_query', 'timestamp:[* TO NOW]'),
   );
   $form['islandora_solr_tabs']['query_defaults']['islandora_solr_base_sort'] = array(
     '#type' => 'textfield',
     '#title' => t('Sort field for default query'),
     '#size' => 30,
-    '#description' => t('Indicate which field should define the sort order for the default query.<br />Consider <strong>timestamp desc</strong>.<br /><strong>Note:</strong> not all fields are sortable. For more info check the <a href="!url">Solr documentation</a>.', array('!url' => 'http://wiki.apache.org/solr/CommonQueryParameters#sort')),
+    '#description' => t('Indicates which field should define the sort order for the default query.<br />Consider using <strong>timestamp desc</strong>.<br /><strong>Note:</strong> not all fields are sortable. For more information, check the <a href="!url">Solr documentation</a>.', array('!url' => 'http://wiki.apache.org/solr/CommonQueryParameters#sort')),
     '#default_value' => variable_get('islandora_solr_base_sort', 'score desc'),
   );
   $form['islandora_solr_tabs']['query_defaults']['islandora_solr_base_filter'] = array(
     '#type' => 'textarea',
     '#title' => t('Solr base filter'),
-    '#description' => t('Some base filters to append to all user queries -- may be used to filter results and to facilitate null-query browsing. Enter one per line. <br />
+    '#description' => t('Lists base filters that are appended to all user queries. This may be used to filter results and facilitate null-query browsing. Enter one filter per line. <br />
       These filters will be applied to all queries in addition to any user-selected facet filters'),
     '#default_value' => variable_get('islandora_solr_base_filter', ''),
     '#wysiwyg' => FALSE,
@@ -450,7 +450,7 @@ function islandora_solr_admin_settings($form, &$form_state) {
     '#type' => 'textfield',
     '#title' => t('Content model Solr field'),
     '#size' => 30,
-    '#description' => t('The Solr field containing the content model URIs. This should be a multivalued string field'),
+    '#description' => t('Solr field containing the content model URIs. This should be a multivalued string field'),
     '#default_value' => variable_get('islandora_solr_content_model_field', 'RELS_EXT_hasModel_uri_ms'),
     '#required' => TRUE,
   );
@@ -459,8 +459,8 @@ function islandora_solr_admin_settings($form, &$form_state) {
     '#type' => 'textfield',
     '#title' => t('Datastream ID Solr field'),
     '#size' => 30,
-    '#description' => t('The Solr field containing the populated datastream IDs.
-      This should be a multivalued string field. If this field is not populated
+    '#description' => t('Solr field containing the populated datastream IDs.
+      This should be a multivalued string field. If this field is not populated,
       the DSID of TN will be assumed valid for thumbnails.'),
     '#default_value' => variable_get('islandora_solr_datastream_id_field', 'fedora_datastreams_ms'),
     '#required' => TRUE,
@@ -488,7 +488,7 @@ function islandora_solr_admin_settings($form, &$form_state) {
     '#title' => t('Debug mode?'),
     '#return_value' => 1,
     '#default_value' => variable_get('islandora_solr_debug_mode', 0),
-    '#description' => t('Dumps solr query to the screen for testing. Warning: if you have the Drupal Apache Solr module enabled alongside this one then the debug function will not work.'),
+    '#description' => t('Dumps Solr queries to the screen for testing. Warning: if you have the Drupal Apache Solr module enabled alongside this one, the debug function will not work.'),
     '#weight' => 6,
   );
 
@@ -526,7 +526,7 @@ function islandora_solr_admin_settings($form, &$form_state) {
   );
 
   if (!empty($_POST) && form_get_errors()) {
-    drupal_set_message(t('The settings have not been saved because of the errors.'), 'error');
+    drupal_set_message(t('Error: the settings have not been saved.'), 'error');
   }
   return $form;
 }
@@ -915,7 +915,7 @@ function theme_islandora_solr_admin_primary_display($variables) {
   $header[] = array('data' => t('Default'));
   $header[] = array('data' => t('Enabled'));
   $header[] = array('data' => t('Name'));
-  $header[] = array('data' => t('Machine readable name'));
+  $header[] = array('data' => t('Machine-readable name'));
   $header[] = array('data' => t('Weight'));
   $header[] = array('data' => t('Configuration'));
   // render form
@@ -1384,20 +1384,20 @@ function islandora_solr_admin_settings_result_fields($form, &$form_state, $varia
     '#type' => 'textfield',
     '#title' => t('Label'),
     '#default_value' => $values['label'],
-    '#description' => t('A human readable name.'),
+    '#description' => t('A human-readable name.'),
   );
 
   $form['options']['link_to_object'] = array(
     '#type' => 'checkbox',
     '#title' => t('Link to object'),
     '#default_value' => $values['link_to_object'],
-    '#description' => t('Link this field to the object page.'),
+    '#description' => t('Link this field to the object\'s page.'),
   );
   $form['options']['snippet'] = array(
     '#type' => 'checkbox',
     '#title' => t('Highlight'),
     '#default_value' => $values['snippet'],
-    '#description' => t('If a match is found on this field, the search term will be highlighted.<br /><strong>Note:</strong> Only text that has been both indexed and stored may be highlighted. While highlighting on non-tokenized fields is possible, the best results are achieved using tokenized fields. The checkbox may be grayed out if the Solr field cannot be highlighted.'),
+    '#description' => t('If a match is found on this field, the search term will be highlighted.<br /><strong>Note:</strong> Only text that has been both indexed and stored may be highlighted. While highlighting on non-tokenized fields is possible, the best results are achieved using tokenized fields. This checkbox may be grayed out if the Solr field cannot be highlighted.'),
   );
   $highlighting_allowed = islandora_solr_check_highlighting_allowed($solr_field);
   if ($highlighting_allowed == FALSE) {
@@ -1416,7 +1416,7 @@ function islandora_solr_admin_settings_result_fields($form, &$form_state, $varia
     '#title' => t('Permissions'),
     '#options' => user_roles(),
     '#default_value' => !empty($permissions) ? $permissions : $permissions_default,
-    '#description' => t('Select what role can access this field.<br /><strong>Note:</strong> checkboxes may be grayed out for roles who do not have permission to search the Solr index.'),
+    '#description' => t('Select which roles can access this field.<br /><strong>Note:</strong> checkboxes may be grayed out for roles which do not have permission to search the Solr index.'),
   );
   foreach ($permissions_disable as $rid) {
     $form['options']['permissions_fieldset']['permissions'][$rid] = array(
@@ -1473,7 +1473,7 @@ function islandora_solr_admin_settings_sort_fields($form, &$form_state, $variabl
     '#type' => 'textfield',
     '#title' => t('Label'),
     '#default_value' => $values['label'],
-    '#description' => t('A human readable name.'),
+    '#description' => t('A human-readable name.'),
   );
   $form['options']['permissions_fieldset'] = array(
     '#type' => 'fieldset',
@@ -1486,7 +1486,7 @@ function islandora_solr_admin_settings_sort_fields($form, &$form_state, $variabl
     '#title' => t('Permissions'),
     '#options' => user_roles(),
     '#default_value' => !empty($permissions) ? $permissions : $permissions_default,
-    '#description' => t('Select what role can access this field.<br /><strong>Note:</strong> checkboxes may be grayed out for roles who do not have permission to search the Solr index.'),
+    '#description' => t('Select which roles can access this field.<br /><strong>Note:</strong> checkboxes may be grayed out for roles which do not have permission to search the Solr index.'),
   );
   foreach ($permissions_disable as $rid) {
     $form['options']['permissions_fieldset']['permissions'][$rid] = array(
@@ -1543,7 +1543,7 @@ function islandora_solr_admin_settings_facet_fields($form, &$form_state, $variab
     '#type' => 'textfield',
     '#title' => t('Label'),
     '#default_value' => $values['label'],
-    '#description' => t('A human readable name.'),
+    '#description' => t('A human-readable name.'),
   );
 
   $form['options']['range_facet'] = array(
@@ -1557,7 +1557,7 @@ function islandora_solr_admin_settings_facet_fields($form, &$form_state, $variab
     '#type' => 'checkbox',
     '#title' => t('Range facet'),
     '#default_value' => $values['range_facet_select'],
-    '#description' => t('Whether this facet field should be configured as a Solr range facet.'),
+    '#description' => t('Toggles whether this facet field should be configured as a Solr range facet.'),
   );
 
   // @TODO: check for non-ajax values
@@ -1574,31 +1574,31 @@ function islandora_solr_admin_settings_facet_fields($form, &$form_state, $variab
     '#title' => t('Variable range gap'),
     '#return_value' => 1,
     '#default_value' => $values['range_facet_variable_gap'] ? $values['range_facet_variable_gap'] : 0,
-    '#description' => t('When checked, the following date range settings will be used as a default. If a date range is filtered down, a new date range gap will be calculated and applied. When unchecked the following settings provide fixed range gaps.'),
+    '#description' => t('When checked, the following date range settings will be used by default, but if a date range is filtered down, a new range gap will be calculated and applied. When left unchecked, the following settings provide fixed range gaps.'),
   );
   $form['options']['range_facet']['wrapper']['range_facet_start'] = array(
     '#type' => 'textfield',
     '#title' => t('Start'),
     '#default_value' => $values['range_facet_start'] ? $values['range_facet_start'] : 'NOW/YEAR-20YEARS',
-    '#description' => t('The lower bound for the first date range for all Date Faceting on this field. This should be a single date expression which may use the <a href="!url">DateMathParser</a> syntax.', array('!url' => 'http://lucene.apache.org/solr/api/org/apache/solr/util/DateMathParser.html')),
+    '#description' => t('The lower bound of the first date range for all date faceting on this field. This should be a single date expression which may use the <a href="!url">DateMathParser</a> syntax.', array('!url' => 'http://lucene.apache.org/solr/api/org/apache/solr/util/DateMathParser.html')),
   );
   $form['options']['range_facet']['wrapper']['range_facet_end'] = array(
     '#type' => 'textfield',
     '#title' => t('End'),
     '#default_value' => $values['range_facet_end'] ? $values['range_facet_end'] : 'NOW',
-    '#description' => t('The minimum upper bound for the last date range for all Date Faceting on this field. This should be a single date expression which may use the <a href="!url">DateMathParser</a> syntax.', array('!url' => 'http://lucene.apache.org/solr/api/org/apache/solr/util/DateMathParser.html')),
+    '#description' => t('The minimum upper bound of the last date range for all Date Faceting on this field. This should be a single date expression which may use the <a href="!url">DateMathParser</a> syntax.', array('!url' => 'http://lucene.apache.org/solr/api/org/apache/solr/util/DateMathParser.html')),
   );
   $form['options']['range_facet']['wrapper']['range_facet_gap'] = array(
     '#type' => 'textfield',
     '#title' => t('Gap'),
     '#default_value' => $values['range_facet_gap'] ? $values['range_facet_gap'] : '+1YEAR',
-    '#description' => t('The size of each date range expressed as an interval to be added to the lower bound using the <a href="!url">DateMathParser</a> syntax.', array('!url' => 'http://lucene.apache.org/solr/api/org/apache/solr/util/DateMathParser.html')),
+    '#description' => t('The size of each date range, expressed as an interval to be added to the lower bound using the <a href="!url">DateMathParser</a> syntax.', array('!url' => 'http://lucene.apache.org/solr/api/org/apache/solr/util/DateMathParser.html')),
   );
   $form['options']['range_facet']['wrapper']['date_facet_format'] = array(
     '#type' => 'textfield',
     '#title' => t('Date format'),
     '#default_value' => $values['date_facet_format'] ? $values['date_facet_format'] : 'Y',
-    '#description' => t('The format of the date as it will be displayed in the facet block. Use the <a href="!url">PHP date()</a> formatting.', array('!url' => 'http://lucene.apache.org/solr/api/org/apache/solr/util/DateMathParser.html')),
+    '#description' => t('The format of the date, as it will be displayed in the facet block. Use <a href="!url">PHP date()</a> formatting.', array('!url' => 'http://lucene.apache.org/solr/api/org/apache/solr/util/DateMathParser.html')),
   );
 
   // Range slider.
@@ -1618,8 +1618,8 @@ function islandora_solr_admin_settings_facet_fields($form, &$form_state, $variab
   $form['options']['range_facet']['wrapper']['range_slider']['range_facet_slider_color'] = array(
     '#type' => 'textfield',
     '#title' => t('Slider color'),
-    '#description' => t('A color for the range slider. Defaults to #edc240'),
-    '#default_value' => $values['range_facet_slider_color'] ? $values['range_facet_slider_color'] : '#edc240',
+    '#description' => t('The range slider\'s color, formatted as a hex value. Defaults to <font color="!color">#EDC240</font>', array('!color' => '#EDC240')),
+    '#default_value' => $values['range_facet_slider_color'] ? $values['range_facet_slider_color'] : '#EDC240',
     '#states' => array(
       'visible' => array(
         ':input[name="range_facet_slider_enabled"]' => array('checked' => TRUE)
@@ -1639,7 +1639,7 @@ function islandora_solr_admin_settings_facet_fields($form, &$form_state, $variab
     '#title' => t('Enable date range filter'),
     '#return_value' => 1,
     '#default_value' => $values['date_filter_datepicker_enabled'] ? $values['date_filter_datepicker_enabled'] : 0,
-    '#description' => t('When checked, a date range filter will become available underneath the date range facets. The date range filter includes a <em>from date</em> and a <em>to date</em> textfield. It comes with a calendar popup widget.'),
+    '#description' => t('When checked, a date range filter will become available underneath the date range facet. The date range filter includes <em>from date</em> and a <em>to date</em> text fields. It also comes with a calendar popup widget.'),
   );
   $form['options']['range_facet']['wrapper']['date_filter']['date_filter_datepicker_range'] = array(
     '#type' => 'textfield',
@@ -1647,7 +1647,7 @@ function islandora_solr_admin_settings_facet_fields($form, &$form_state, $variab
     '#default_value' => $values['date_filter_datepicker_range'] ? $values['date_filter_datepicker_range'] : '-100:+3',
     '#size' => 10,
     '#maxsize' => 10,
-    '#description' => t('The range of years displayed in the year drop-down: either relative to today\'s year ("-nn:+nn"), relative to the currently selected year ("c-nn:c+nn"), absolute ("nnnn:nnnn"), or combinations of these formats ("nnnn:-nn"). For more info, check the jQuery UI <a href="!url" target="_blank">datepicker documentation</a>.', array('!url' => 'http://api.jqueryui.com/datepicker/#option-yearRange')),
+    '#description' => t('The range of years displayed in the year drop-down menu. These are either relative to today\'s year ("-nn:+nn"), to the currently selected year ("c-nn:c+nn"), an absolute ("nnnn:nnnn"), or combinations of these formats ("nnnn:-nn"). For more info, check the jQuery UI <a href="!url" target="_blank">datepicker documentation</a>.', array('!url' => 'http://api.jqueryui.com/datepicker/#option-yearRange')),
     '#states' => array(
       'visible' => array(
         ':input[name="date_filter_datepicker_enabled"]' => array('checked' => TRUE)
@@ -1667,7 +1667,7 @@ function islandora_solr_admin_settings_facet_fields($form, &$form_state, $variab
     '#title' => t('Permissions'),
     '#options' => user_roles(),
     '#default_value' => !empty($permissions) ? $permissions : $permissions_default,
-    '#description' => t('Select what role can access this field.<br /><strong>Note:</strong> checkboxes may be grayed out for roles who do not have permission to search the Solr index.'),
+    '#description' => t('Select which roles can access this field.<br /><strong>Note:</strong> checkboxes may be grayed out for roles which do not have permission to search the Solr index.'),
   );
   foreach ($permissions_disable as $rid) {
     $form['options']['permissions_fieldset']['permissions'][$rid] = array(
@@ -1724,7 +1724,7 @@ function islandora_solr_admin_settings_search_fields($form, &$form_state, $varia
     '#type' => 'textfield',
     '#title' => t('Label'),
     '#default_value' => $values['label'],
-    '#description' => t('A human readable name.'),
+    '#description' => t('A human-readable name.'),
   );
   $form['options']['permissions_fieldset'] = array(
     '#type' => 'fieldset',
@@ -1737,7 +1737,7 @@ function islandora_solr_admin_settings_search_fields($form, &$form_state, $varia
     '#title' => t('Permissions'),
     '#options' => user_roles(),
     '#default_value' => !empty($permissions) ? $permissions : $permissions_default,
-    '#description' => t('Select what role can access this field.<br /><strong>Note:</strong> checkboxes may be grayed out for roles who do not have permission to search the Solr index.'),
+    '#description' => t('Select which roles can access this field.<br /><strong>Note:</strong> checkboxes may be grayed out for roles which do not have permission to search the Solr index.'),
   );
   foreach ($permissions_disable as $rid) {
     $form['options']['permissions_fieldset']['permissions'][$rid] = array(

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -1618,7 +1618,7 @@ function islandora_solr_admin_settings_facet_fields($form, &$form_state, $variab
   $form['options']['range_facet']['wrapper']['range_slider']['range_facet_slider_color'] = array(
     '#type' => 'textfield',
     '#title' => t('Slider color'),
-    '#description' => t('The range slider\'s color, formatted as a hex value. Defaults to <span style="color: !color">#edc240</span>', array('!color' => '#edc240')),
+    '#description' => t('The range slider\'s color, formatted as a hex value. Defaults to <span style="color: #edc240">#edc240</span>'),
     '#default_value' => $values['range_facet_slider_color'] ? $values['range_facet_slider_color'] : '#edc240',
     '#states' => array(
       'visible' => array(

--- a/includes/db.inc
+++ b/includes/db.inc
@@ -34,7 +34,7 @@ function islandora_solr_get_fields($field_type = NULL, $filter = TRUE, $simplifi
   }
   catch (Exception $e) {
     if ($e->errorInfo[0] == '42S02') {
-      drupal_set_message(t('Islandora solr fields table not found. Try running <a href="@update_url">update.php</a>.', array('@update_url' => url('update.php'))), 'error');
+      drupal_set_message(t('Islandora Solr fields table not found. Try running <a href="@update_url">update.php</a>.', array('@update_url' => url('update.php'))), 'error');
     }
     else {
       drupal_set_message($e->getMessage(), 'error');

--- a/includes/facets.inc
+++ b/includes/facets.inc
@@ -189,7 +189,7 @@ function islandora_solr_date_filter_form_validate($form, &$form_state) {
 
     // check from date
     if (!checkdate(intval($from[1]), intval($from[2]), intval($from[0]))) {
-      form_set_error($form_key . '][date_filter_from', t('From date isn\'t formatted correctly.'));
+      form_set_error($form_key . '][date_filter_from', t('<em>From</em> date isn\'t formatted correctly.'));
     }
   }
   // if the 'to' value is '*' just skip all checks
@@ -203,7 +203,7 @@ function islandora_solr_date_filter_form_validate($form, &$form_state) {
     }
     // check to date
     if (!checkdate(intval($to[1]), intval($to[2]), intval($to[0]))) {
-      form_set_error($form_key . '][date_filter_to', t('To date isn\'t formatted correctly.'));
+      form_set_error($form_key . '][date_filter_to', t('<em>To</em> date isn\'t formatted correctly.'));
     }
   }
 }

--- a/islandora_solr.api.php
+++ b/islandora_solr.api.php
@@ -20,7 +20,7 @@
 function hook_islandora_solr_primary_display() {
   return array(
     'machine_name' => array(
-      'name' => t('Human readable name'),
+      'name' => t('Human-readable name'),
       'module' => 'module_name',
       'file' => 'FileName.inc',
       'class' => 'ClassName',
@@ -41,7 +41,7 @@ function hook_islandora_solr_primary_display() {
 function hook_islandora_solr_secondary_display() {
   return array(
     'machine_name' => array(
-      'name' => t('Human readable name'),
+      'name' => t('Human-readable name'),
       'module' => 'module_name',
       'file' => 'FileName.inc',
       'class' => 'ClassName',
@@ -87,7 +87,7 @@ function hook_islandora_solr_query($islandora_solr_query) {
 function hook_islandora_solr_query_blocks() {
   return array(
     'machine_name' => array(
-      'name' => t('Human Readable Name'),
+      'name' => t('Human-Readable Name'),
       'module' => 'module_name',
       'file' => 'FileName.inc',
       'class' => 'ClassName',

--- a/islandora_solr.info
+++ b/islandora_solr.info
@@ -1,6 +1,6 @@
 name = Islandora Solr
 dependencies[] = islandora
-description = Searches an islandora solr index
+description = Searches an Islandora Solr index
 package = Islandora Search
 configure = admin/config/islandora_solr
 version = 7.x-dev

--- a/islandora_solr.install
+++ b/islandora_solr.install
@@ -36,8 +36,8 @@ function islandora_solr_requirements($phase) {
     if (!class_exists('Apache_Solr_Service')) {
       $requirements['islandora_solr'] = array(
         'title' => $t('Missing Apache Client'),
-        'description' => $t('This module requires the !client_link.  Please install the client directory in the root directory of this module before continuing.', array(
-          '!client_link' => l('Apache Solr php client', 'http://code.google.com/p/solr-php-client'),
+        'description' => $t('This module requires the !client_link.  Please install the client in the root directory of this module before continuing.', array(
+          '!client_link' => l('Apache Solr PHP Client', 'http://code.google.com/p/solr-php-client'),
         )),
         'severity' => REQUIREMENT_ERROR,
       );

--- a/islandora_solr.module
+++ b/islandora_solr.module
@@ -54,7 +54,7 @@ function islandora_solr_menu() {
     'type' => MENU_CALLBACK,
   );
   $items['admin/islandora/search/islandora_solr'] = array(
-    'title' => 'Solr client',
+    'title' => 'Solr Client',
     'description' => 'Configure Solr search settings.',
     'page callback' => 'drupal_get_form',
     'page arguments' => array('islandora_solr_admin_settings'),
@@ -64,7 +64,7 @@ function islandora_solr_menu() {
   );
   $items['islandora_solr/field'] = array(
     'title' => 'Result field',
-    'description' => 'Configuration for result field',
+    'description' => 'Configuration for Solr result field',
     'page callback' => 'islandora_solr_admin_settings_field',
     'page arguments' => array(2, 3),
     'access arguments' => array('administer islandora solr'),
@@ -252,7 +252,7 @@ function islandora_solr($query = NULL) {
   $_islandora_solr_queryclass->buildAndExecuteQuery($query, $params);
 
   if (empty($_islandora_solr_queryclass->islandoraSolrResult)) {
-    return t('Error searching solr index.');
+    return t('Error searching Solr index.');
   }
 
   // TODO: Also filter secondary displays against those checked in the configuration options.
@@ -263,7 +263,7 @@ function islandora_solr($query = NULL) {
     $profile = $primary_profiles[$islandora_solr_primary_display];
   }
   else {
-    drupal_set_message(check_plain(t('There is an error in the solr search configuration: the display profile is not found.')), 'error');
+    drupal_set_message(check_plain(t('There is an error in the Solr search configuration: the display profile is not found.')), 'error');
     $profile = $primary_profiles['default'];
   }
   // Include the file for the display profile
@@ -294,7 +294,7 @@ function islandora_solr($query = NULL) {
 
   // debug dump
   if (variable_get('islandora_solr_debug_mode', 0)) {
-    $message = t('Params: <br /><pre>!debug</pre>', array('!debug' => print_r($_islandora_solr_queryclass->solrParams, TRUE)));
+    $message = t('Parameters: <br /><pre>!debug</pre>', array('!debug' => print_r($_islandora_solr_queryclass->solrParams, TRUE)));
     drupal_set_message(filter_xss($message, array('pre', 'br')), 'status');
   }
 

--- a/islandora_solr_config/includes/csv_results.inc
+++ b/islandora_solr_config/includes/csv_results.inc
@@ -159,7 +159,7 @@ class IslandoraSolrResultsCSV extends IslandoraSolrResults {
       print implode($seperator, $row) . "\r\n";
     }
 
-    drupal_set_message(check_plain(t('Exported !count records from index to CSV', array('!count' => $count + 1))));
+    drupal_set_message(check_plain(t('Exported !count records from the index to CSV.', array('!count' => $count + 1))));
 
     fclose($docfile);
 

--- a/islandora_solr_config/islandora_solr_config.info
+++ b/islandora_solr_config/islandora_solr_config.info
@@ -1,5 +1,5 @@
 name = Islandora Solr display profiles
-description = Display profiles for Islandora Solr. (Grid, Table and CSV)
+description = Display profiles for Islandora Solr (Grid, Table and CSV).
 dependencies[] = islandora_solr
 files[] = includes/csv_results.inc
 files[] = includes/grid_results.inc

--- a/islandora_solr_config/islandora_solr_config.module
+++ b/islandora_solr_config/islandora_solr_config.module
@@ -24,7 +24,7 @@ function islandora_solr_config_islandora_solr_primary_display() {
       'file' => 'includes/grid_results.inc',
       'class' => "IslandoraSolrResultsGrid",
       'function' => "displayResults",
-      'description' => t("Search results as a grid view"),
+      'description' => t("Display search results as a grid view"),
     ),
     'table' => array(
       'name' => t('Table'),
@@ -32,7 +32,7 @@ function islandora_solr_config_islandora_solr_primary_display() {
       'file' => 'includes/table_results.inc',
       'class' => "IslandoraSolrResultsTable",
       'function' => "displayResults",
-      'description' => t("Search results as tabular output"),
+      'description' => t("Display search results as tabular output"),
     ),
   );
 }


### PR DESCRIPTION
Many, many changes. Half style and clarity, half consistency - especially proper capitalization of 'Solr'. Added colour to the description of the default range slider facet hex value, for clarity's sake (includes/admin.inc lines 1621-22).
