### PR TITLE
7.x various updates

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -52,10 +52,11 @@ http://drupal.stackexchange.com/questions/50216/how-to-trigger-a-form-and-pass-v
 -- look for details (permissions, string handling, css, etc..)
 -- rss feed + config
 
+- update README.txt
+
 Normal Priority
 ---------------
 
-- Try to fix popup resizing.
 - rename 'solr_field_settings' to 'settings'
 - really need to clean IslandoraSolrResults. All of it, but especially facets.
 - use libraries module for flot
@@ -80,7 +81,6 @@ http://wiki.apache.org/solr/CommonQueryParameters#sort
 Low Priority
 ------------
 
-- update README.txt
 - tabledrag should update the table with ajax.
 - hook_alter instead of module invoke all for object manipulation
 - provide integration with display suite

--- a/TODO.txt
+++ b/TODO.txt
@@ -40,8 +40,6 @@ http://drupal.stackexchange.com/questions/50216/how-to-trigger-a-form-and-pass-v
 
 - make labels translatable: http://drupal.org/node/1114010
 
-- separate preparing results from display
-- result permissions only enforced on default display
 - we could save us some code by storing the primary display settings in a DB table
 - add luke check for date fields (breaks if not)
 - more user friendly controls + advanced option
@@ -58,12 +56,10 @@ Normal Priority
 ---------------
 
 - rename 'solr_field_settings' to 'settings'
-- really need to clean IslandoraSolrResults. All of it, but especially facets.
+- clean up IslandoraSolrResults.
 - use libraries module for flot
-- fix snippet field highlighting
 - Facet settings: add checkbox to display facet as a separate block. Can be nice for sliders to display in the content top or bottom.
 - improve settings display. add little icon with settings in tooltip? misc/message-16-help.png
-- split out highlighting true by default. Don't include unless at least one field is given.
 - add ability to add permission callback or permission id to solr display profiles
 - add a check to see if the context is the search results page. Currently we
 check if IslandoraSolrQueryProcessor::display is set, which is not ideal.
@@ -72,10 +68,8 @@ check if IslandoraSolrQueryProcessor::display is set, which is not ideal.
 - check if spaces could be replaced by + or %20 , which would simplify some functions (splitting strings)
 http://wiki.apache.org/solr/CommonQueryParameters#sort
 - don't hardcode php solr library, instead override it.
-- table display works but should be rendered through a template file.
 - add ajax_command_changed() to the vertical tabs to show something has changed.
 - add watchdog messages on error.
-- on query without filter parameters the delete link adds a ? or &
 - some snippets of markup could go in theme functions
 
 Low Priority
@@ -84,9 +78,6 @@ Low Priority
 - tabledrag should update the table with ajax.
 - hook_alter instead of module invoke all for object manipulation
 - provide integration with display suite
-- expose result limit controls
-- put object url's in one variable?
 - Boolean operators as query seem to choke
 
 - when changing primary display, keep &limit in the url or should it show the default? Displays can override this though.
-- empty query with dismax seems to return the same as no dismax (maybe it's just how solrconfig is defined)

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -419,8 +419,8 @@ function islandora_solr_admin_settings($form, &$form_state) {
     '#type' => 'textfield',
     '#title' => t('Sort field for default query'),
     '#size' => 30,
-    '#description' => t('Indicates which field should define the sort order for the default query.<br />Consider using <strong>timestamp desc</strong>.<br /><strong>Note:</strong> not all fields are sortable. For more information, check the <a href="!url">Solr documentation</a>.', array('!url' => 'http://wiki.apache.org/solr/CommonQueryParameters#sort')),
-    '#default_value' => variable_get('islandora_solr_base_sort', 'score desc'),
+    '#description' => t('Indicates which field should define the sort order for the default query.<br />For example: <strong>timestamp desc</strong>.<br /><strong>Note:</strong> not all fields are sortable. For more information, check the <a href="!url">Solr documentation</a>.', array('!url' => 'http://wiki.apache.org/solr/CommonQueryParameters#sort')),
+    '#default_value' => variable_get('islandora_solr_base_sort', ''),
   );
   $form['islandora_solr_tabs']['query_defaults']['islandora_solr_base_filter'] = array(
     '#type' => 'textarea',

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -1274,21 +1274,22 @@ function _islandora_solr_handle_solr_field_settings($solr_field_settings = NULL,
     switch ($field_type) {
       case 'result_fields':
         return array(
-          'label' => $solr_field_settings['label'],
+          'label' => trim($solr_field_settings['label']),
           'link_to_object' => $solr_field_settings['link_to_object'],
           'snippet' => $solr_field_settings['snippet'],
+          'date_format' => trim($solr_field_settings['date_format']),
           'permissions' => $solr_field_settings['permissions'],
         );
         break;
       case 'sort_fields':
         return array(
-          'label' => $solr_field_settings['label'],
+          'label' => trim($solr_field_settings['label']),
           'permissions' => $solr_field_settings['permissions'],
         );
         break;
       case 'facet_fields':
         return array(
-          'label' => $solr_field_settings['label'],
+          'label' => trim($solr_field_settings['label']),
           'range_facet_select' => $solr_field_settings['range_facet_select'],
           'range_facet_variable_gap' => $solr_field_settings['range_facet_variable_gap'],
           'range_facet_start' => $solr_field_settings['range_facet_start'],
@@ -1304,7 +1305,7 @@ function _islandora_solr_handle_solr_field_settings($solr_field_settings = NULL,
         break;
       case 'search_fields':
         return array(
-          'label' => $solr_field_settings['label'],
+          'label' => trim($solr_field_settings['label']),
           'permissions' => $solr_field_settings['permissions'],
         );
         break;
@@ -1403,6 +1404,16 @@ function islandora_solr_admin_settings_result_fields($form, &$form_state, $varia
   if ($highlighting_allowed == FALSE) {
     $form['options']['snippet']['#default_value'] = 0;
     $form['options']['snippet']['#disabled'] = TRUE;
+  }
+
+  $luke_result = islandora_solr_get_luke(NULL, $solr_field);
+  if(isset($luke_result['fields'][$solr_field]['type']) && $luke_result['fields'][$solr_field]['type'] == 'date') {
+    $form['options']['date_format'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Date format'),
+      '#default_value' => $values['date_format'] ? $values['date_format'] : '',
+      '#description' => t('The format of the date, as it will be displayed in the search results. Use <a href="!url" target="_blank">PHP date()</a> formatting.', array('!url' => 'http://lucene.apache.org/solr/api/org/apache/solr/util/DateMathParser.html')),
+    );
   }
 
   $form['options']['permissions_fieldset'] = array(

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -6,21 +6,12 @@
  */
 
 /**
- * Function to return administration setting form
- *
- * @param array $form
- *   The form deffinition.
- * @param array $form_state
- *   The form state.
- *
- * @return array
- *   The form array.
+ * Islandora Solr index admin form.
  */
-function islandora_solr_admin_settings($form, &$form_state) {
+function islandora_solr_admin_index_settings($form, &$form_state) {
   // Add admin form css.
   drupal_add_css(drupal_get_path('module', 'islandora_solr') . '/css/islandora_solr.admin.css');
-  drupal_add_library('system', 'ui.dialog');
-  drupal_add_js(drupal_get_path('module', 'islandora_solr') . '/js/islandora_solr.admin.js');
+
   $solr_url = !empty($form_state['values']['islandora_solr_url']) ? $form_state['values']['islandora_solr_url'] : variable_get('islandora_solr_url', 'localhost:8080/solr');
 
   // Solr connect triggering handler is dismax or not set on page load.
@@ -61,10 +52,6 @@ function islandora_solr_admin_settings($form, &$form_state) {
   }
   // Create form.
   $form = array();
-  $form['islandora_solr_tabs'] = array(
-    '#type' => 'vertical_tabs',
-    '#weight' => 5,
-  );
   // ajax wrapper for url checking
   $form['solr_ajax_wrapper'] = array(
     '#prefix' => '<div id="solr-url">',
@@ -123,8 +110,93 @@ function islandora_solr_admin_settings($form, &$form_state) {
       ),
     );
   }
+  $form['solr_ajax_wrapper']['islandora_solr_available'] = array(
+    '#type' => 'hidden',
+    '#value' => $solr_avail ? 1 : 0,
+  );
 
+  // Actions.
+  $form['actions'] = array(
+    '#type' => 'actions',
+  );
+  $form['actions']['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Save Solr configuration'),
+    '#weight' => 0,
+    '#submit' => array('_islandora_solr_admin_index_settings_submit'),
+    '#validate' => array('_islandora_solr_admin_index_settings_validate'),
+  );
+  $form['actions']['reset'] = array(
+    '#type' => 'submit',
+    '#value' => t('Reset to defaults'),
+    '#weight' => 1,
+    '#submit' => array('_islandora_solr_admin_index_settings_submit'),
+  );
+  return $form;
+}
 
+/**
+ * Islandora Solr index admin validate callback.
+ */
+function _islandora_solr_admin_index_settings_validate($form, &$form_state) {
+  if ($form_state['values']['islandora_solr_available'] == 0) {
+    form_set_error('islandora_solr_url', t('Please enter a valid Solr URL.'));
+    $form_state['rebuild'] = TRUE;
+  }
+}
+
+/**
+ * Islandora Solr index admin submit callback.
+ */
+function _islandora_solr_admin_index_settings_submit($form, &$form_state) {
+  // if this function is called not using submit or reset buttons
+  if ($form_state['triggering_element']['#id'] != 'edit-submit' && $form_state['triggering_element']['#id'] != 'edit-reset') {
+    $form_state['rebuild'] = TRUE;
+    return;
+  }
+  // get operation
+  $op = isset($form_state['triggering_element']['#id']) ? $form_state['triggering_element']['#id'] : '';
+
+  switch ($op) {
+    case 'edit-submit':
+      variable_set('islandora_solr_url', $form_state['values']['islandora_solr_url']);
+      variable_set('islandora_solr_request_handler', $form_state['values']['islandora_solr_request_handler']);
+      variable_set('islandora_solr_dismax_allowed', $form_state['values']['islandora_solr_dismax_allowed']);
+      drupal_set_message(t('The Solr configuration options have been saved.'));
+      break;
+    case 'edit-reset':
+      variable_del('islandora_solr_url');
+      variable_del('islandora_solr_request_handler');
+      variable_del('islandora_solr_dismax_allowed');
+      drupal_set_message(t('The configuration options have been reset to their default values.'));
+      break;
+  }
+}
+
+/**
+ * Function to return administration setting form
+ *
+ * @param array $form
+ *   The form deffinition.
+ * @param array $form_state
+ *   The form state.
+ *
+ * @return array
+ *   The form array.
+ */
+function islandora_solr_admin_settings($form, &$form_state) {
+  // Add admin form css.
+  drupal_set_title(t('Solr settings'));
+  drupal_add_css(drupal_get_path('module', 'islandora_solr') . '/css/islandora_solr.admin.css');
+  drupal_add_library('system', 'ui.dialog');
+  drupal_add_js(drupal_get_path('module', 'islandora_solr') . '/js/islandora_solr.admin.js');
+
+  // Create form.
+  $form = array();
+  $form['islandora_solr_tabs'] = array(
+    '#type' => 'vertical_tabs',
+    '#weight' => 5,
+  );
   // display profiles
   $form['display_profiles'] = array(
     '#type' => 'fieldset',
@@ -1025,7 +1097,7 @@ function _islandora_solr_admin_settings_submit($form, &$form_state) {
       }
 
       // set save message
-      drupal_set_message(t('The solr configuration options have been saved.'));
+      drupal_set_message(t('The Solr configuration options have been saved.'));
       break;
     case t('Reset to defaults'):
       // loop over all submitted values
@@ -1042,11 +1114,12 @@ function _islandora_solr_admin_settings_submit($form, &$form_state) {
       db_delete('islandora_solr_fields')->execute();
 
       // set reset message
-      drupal_set_message(t('The configuration options have been reset to their default values.')); // @TODO: these don't seem to work anymore
+      drupal_set_message(t('The configuration options have been reset to their default values.'));
       break;
   }
 
   // clear caches
+  // @TODO: is this still necessary?
   cache_clear_all();
   drupal_theme_rebuild();
 }
@@ -1566,14 +1639,14 @@ function islandora_solr_admin_settings_facet_fields($form, &$form_state, $variab
       '#collapsible' => FALSE,
       '#collapsed' => TRUE,
     );
-  
+
     $form['options']['range_facet']['range_facet_select'] = array(// @TODO: grey out if LUKE says it's not possible to use as a range field? Add AJAX callback to show more options?
       '#type' => 'checkbox',
       '#title' => t('Range facet'),
       '#default_value' => $values['range_facet_select'],
       '#description' => t('Toggles whether this facet field should be configured as a Solr range facet.'),
     );
-  
+
     // @TODO: check for non-ajax values
     $form['options']['range_facet']['wrapper'] = array(
       '#type' => 'container',
@@ -1614,7 +1687,7 @@ function islandora_solr_admin_settings_facet_fields($form, &$form_state, $variab
       '#default_value' => $values['date_facet_format'] ? $values['date_facet_format'] : 'Y',
       '#description' => t('The format of the date, as it will be displayed in the facet block. Use <a href="!url">PHP date()</a> formatting.', array('!url' => 'http://lucene.apache.org/solr/api/org/apache/solr/util/DateMathParser.html')),
     );
-  
+
     // Range slider.
     $form['options']['range_facet']['wrapper']['range_slider'] = array(
       '#type' => 'fieldset',
@@ -1640,7 +1713,7 @@ function islandora_solr_admin_settings_facet_fields($form, &$form_state, $variab
         ),
       ),
     );
-  
+
     // Date filter
     $form['options']['range_facet']['wrapper']['date_filter'] = array(
       '#type' => 'fieldset',

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -1539,6 +1539,7 @@ function islandora_solr_admin_settings_facet_fields($form, &$form_state, $variab
 
   $form_state['dialog'] = $variables;
   // get solr field values
+  $solr_field = $variables['solr_field'];
   $values = $variables['values'];
   $permissions = $values['permissions'];
   $permissions_disable = _islandora_solr_permissions_disable();
@@ -1557,114 +1558,117 @@ function islandora_solr_admin_settings_facet_fields($form, &$form_state, $variab
     '#description' => t('A human-readable name.'),
   );
 
-  $form['options']['range_facet'] = array(
-    '#type' => 'fieldset',
-    '#id' => 'range-facet-wrapper',
-    '#collapsible' => FALSE,
-    '#collapsed' => TRUE,
-  );
-
-  $form['options']['range_facet']['range_facet_select'] = array(// @TODO: grey out if LUKE says it's not possible to use as a range field? Add AJAX callback to show more options?
-    '#type' => 'checkbox',
-    '#title' => t('Range facet'),
-    '#default_value' => $values['range_facet_select'],
-    '#description' => t('Toggles whether this facet field should be configured as a Solr range facet.'),
-  );
-
-  // @TODO: check for non-ajax values
-  $form['options']['range_facet']['wrapper'] = array(
-    '#type' => 'container',
-    '#states' => array(
-      'visible' => array(
-        ':input[name="range_facet_select"]' => array('checked' => TRUE)
+  $luke_result = islandora_solr_get_luke(NULL, $solr_field);
+  if(isset($luke_result['fields'][$solr_field]['type']) && $luke_result['fields'][$solr_field]['type'] == 'date') {
+    $form['options']['range_facet'] = array(
+      '#type' => 'fieldset',
+      '#id' => 'range-facet-wrapper',
+      '#collapsible' => FALSE,
+      '#collapsed' => TRUE,
+    );
+  
+    $form['options']['range_facet']['range_facet_select'] = array(// @TODO: grey out if LUKE says it's not possible to use as a range field? Add AJAX callback to show more options?
+      '#type' => 'checkbox',
+      '#title' => t('Range facet'),
+      '#default_value' => $values['range_facet_select'],
+      '#description' => t('Toggles whether this facet field should be configured as a Solr range facet.'),
+    );
+  
+    // @TODO: check for non-ajax values
+    $form['options']['range_facet']['wrapper'] = array(
+      '#type' => 'container',
+      '#states' => array(
+        'visible' => array(
+          ':input[name="range_facet_select"]' => array('checked' => TRUE)
+        ),
       ),
-    ),
-  );
-  $form['options']['range_facet']['wrapper']['range_facet_variable_gap'] = array(
-    '#type' => 'checkbox',
-    '#title' => t('Variable range gap'),
-    '#return_value' => 1,
-    '#default_value' => $values['range_facet_variable_gap'] ? $values['range_facet_variable_gap'] : 0,
-    '#description' => t('When checked, the following date range settings will be used by default, but if a date range is filtered down, a new range gap will be calculated and applied. When left unchecked, the following settings provide fixed range gaps.'),
-  );
-  $form['options']['range_facet']['wrapper']['range_facet_start'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Start'),
-    '#default_value' => $values['range_facet_start'] ? $values['range_facet_start'] : 'NOW/YEAR-20YEARS',
-    '#description' => t('The lower bound of the first date range for all date faceting on this field. This should be a single date expression which may use the <a href="!url">DateMathParser</a> syntax.', array('!url' => 'http://lucene.apache.org/solr/api/org/apache/solr/util/DateMathParser.html')),
-  );
-  $form['options']['range_facet']['wrapper']['range_facet_end'] = array(
-    '#type' => 'textfield',
-    '#title' => t('End'),
-    '#default_value' => $values['range_facet_end'] ? $values['range_facet_end'] : 'NOW',
-    '#description' => t('The minimum upper bound of the last date range for all Date Faceting on this field. This should be a single date expression which may use the <a href="!url">DateMathParser</a> syntax.', array('!url' => 'http://lucene.apache.org/solr/api/org/apache/solr/util/DateMathParser.html')),
-  );
-  $form['options']['range_facet']['wrapper']['range_facet_gap'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Gap'),
-    '#default_value' => $values['range_facet_gap'] ? $values['range_facet_gap'] : '+1YEAR',
-    '#description' => t('The size of each date range, expressed as an interval to be added to the lower bound using the <a href="!url">DateMathParser</a> syntax.', array('!url' => 'http://lucene.apache.org/solr/api/org/apache/solr/util/DateMathParser.html')),
-  );
-  $form['options']['range_facet']['wrapper']['date_facet_format'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Date format'),
-    '#default_value' => $values['date_facet_format'] ? $values['date_facet_format'] : 'Y',
-    '#description' => t('The format of the date, as it will be displayed in the facet block. Use <a href="!url">PHP date()</a> formatting.', array('!url' => 'http://lucene.apache.org/solr/api/org/apache/solr/util/DateMathParser.html')),
-  );
-
-  // Range slider.
-  $form['options']['range_facet']['wrapper']['range_slider'] = array(
-    '#type' => 'fieldset',
-    '#title' => t('Range slider'),
-    '#collapsible' => TRUE,
-    '#collapsed' => FALSE,
-  );
-  $form['options']['range_facet']['wrapper']['range_slider']['range_facet_slider_enabled'] = array(
-    '#type' => 'checkbox',
-    '#title' => t('Enable range slider'),
-    '#return_value' => 1,
-    '#default_value' => $values['range_facet_slider_enabled'] ? $values['range_facet_slider_enabled'] : 0,
-    '#description' => t('When checked, the normal range facet will be replaced by a range slider widget.'),
-  );
-  $form['options']['range_facet']['wrapper']['range_slider']['range_facet_slider_color'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Slider color'),
-    '#description' => t('The range slider\'s color, formatted as a hex value. Defaults to <span style="color: #edc240">#edc240</span>'),
-    '#default_value' => $values['range_facet_slider_color'] ? $values['range_facet_slider_color'] : '#edc240',
-    '#states' => array(
-      'visible' => array(
-        ':input[name="range_facet_slider_enabled"]' => array('checked' => TRUE)
+    );
+    $form['options']['range_facet']['wrapper']['range_facet_variable_gap'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Variable range gap'),
+      '#return_value' => 1,
+      '#default_value' => $values['range_facet_variable_gap'] ? $values['range_facet_variable_gap'] : 0,
+      '#description' => t('When checked, the following date range settings will be used by default, but if a date range is filtered down, a new range gap will be calculated and applied. When left unchecked, the following settings provide fixed range gaps.'),
+    );
+    $form['options']['range_facet']['wrapper']['range_facet_start'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Start'),
+      '#default_value' => $values['range_facet_start'] ? $values['range_facet_start'] : 'NOW/YEAR-20YEARS',
+      '#description' => t('The lower bound of the first date range for all date faceting on this field. This should be a single date expression which may use the <a href="!url">DateMathParser</a> syntax.', array('!url' => 'http://lucene.apache.org/solr/api/org/apache/solr/util/DateMathParser.html')),
+    );
+    $form['options']['range_facet']['wrapper']['range_facet_end'] = array(
+      '#type' => 'textfield',
+      '#title' => t('End'),
+      '#default_value' => $values['range_facet_end'] ? $values['range_facet_end'] : 'NOW',
+      '#description' => t('The minimum upper bound of the last date range for all Date Faceting on this field. This should be a single date expression which may use the <a href="!url">DateMathParser</a> syntax.', array('!url' => 'http://lucene.apache.org/solr/api/org/apache/solr/util/DateMathParser.html')),
+    );
+    $form['options']['range_facet']['wrapper']['range_facet_gap'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Gap'),
+      '#default_value' => $values['range_facet_gap'] ? $values['range_facet_gap'] : '+1YEAR',
+      '#description' => t('The size of each date range, expressed as an interval to be added to the lower bound using the <a href="!url">DateMathParser</a> syntax.', array('!url' => 'http://lucene.apache.org/solr/api/org/apache/solr/util/DateMathParser.html')),
+    );
+    $form['options']['range_facet']['wrapper']['date_facet_format'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Date format'),
+      '#default_value' => $values['date_facet_format'] ? $values['date_facet_format'] : 'Y',
+      '#description' => t('The format of the date, as it will be displayed in the facet block. Use <a href="!url">PHP date()</a> formatting.', array('!url' => 'http://lucene.apache.org/solr/api/org/apache/solr/util/DateMathParser.html')),
+    );
+  
+    // Range slider.
+    $form['options']['range_facet']['wrapper']['range_slider'] = array(
+      '#type' => 'fieldset',
+      '#title' => t('Range slider'),
+      '#collapsible' => TRUE,
+      '#collapsed' => FALSE,
+    );
+    $form['options']['range_facet']['wrapper']['range_slider']['range_facet_slider_enabled'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Enable range slider'),
+      '#return_value' => 1,
+      '#default_value' => $values['range_facet_slider_enabled'] ? $values['range_facet_slider_enabled'] : 0,
+      '#description' => t('When checked, the normal range facet will be replaced by a range slider widget.'),
+    );
+    $form['options']['range_facet']['wrapper']['range_slider']['range_facet_slider_color'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Slider color'),
+      '#description' => t('The range slider\'s color, formatted as a hex value. Defaults to <span style="color: #edc240">#edc240</span>'),
+      '#default_value' => $values['range_facet_slider_color'] ? $values['range_facet_slider_color'] : '#edc240',
+      '#states' => array(
+        'visible' => array(
+          ':input[name="range_facet_slider_enabled"]' => array('checked' => TRUE)
+        ),
       ),
-    ),
-  );
-
-  // Date filter
-  $form['options']['range_facet']['wrapper']['date_filter'] = array(
-    '#type' => 'fieldset',
-    '#title' => t('Date range filter'),
-    '#collapsible' => TRUE,
-    '#collapsed' => FALSE,
-  );
-  $form['options']['range_facet']['wrapper']['date_filter']['date_filter_datepicker_enabled'] = array(
-    '#type' => 'checkbox',
-    '#title' => t('Enable date range filter'),
-    '#return_value' => 1,
-    '#default_value' => $values['date_filter_datepicker_enabled'] ? $values['date_filter_datepicker_enabled'] : 0,
-    '#description' => t('When checked, a date range filter will become available underneath the date range facet. The date range filter includes <em>from date</em> and a <em>to date</em> text fields. It also comes with a calendar popup widget.'),
-  );
-  $form['options']['range_facet']['wrapper']['date_filter']['date_filter_datepicker_range'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Years back and forward'),
-    '#default_value' => $values['date_filter_datepicker_range'] ? $values['date_filter_datepicker_range'] : '-100:+3',
-    '#size' => 10,
-    '#maxsize' => 10,
-    '#description' => t('The range of years displayed in the year drop-down menu. These are either relative to today\'s year ("-nn:+nn"), to the currently selected year ("c-nn:c+nn"), an absolute ("nnnn:nnnn"), or combinations of these formats ("nnnn:-nn"). For more info, check the jQuery UI <a href="!url" target="_blank">datepicker documentation</a>.', array('!url' => 'http://api.jqueryui.com/datepicker/#option-yearRange')),
-    '#states' => array(
-      'visible' => array(
-        ':input[name="date_filter_datepicker_enabled"]' => array('checked' => TRUE)
+    );
+  
+    // Date filter
+    $form['options']['range_facet']['wrapper']['date_filter'] = array(
+      '#type' => 'fieldset',
+      '#title' => t('Date range filter'),
+      '#collapsible' => TRUE,
+      '#collapsed' => FALSE,
+    );
+    $form['options']['range_facet']['wrapper']['date_filter']['date_filter_datepicker_enabled'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Enable date range filter'),
+      '#return_value' => 1,
+      '#default_value' => $values['date_filter_datepicker_enabled'] ? $values['date_filter_datepicker_enabled'] : 0,
+      '#description' => t('When checked, a date range filter will become available underneath the date range facet. The date range filter includes <em>from date</em> and a <em>to date</em> text fields. It also comes with a calendar popup widget.'),
+    );
+    $form['options']['range_facet']['wrapper']['date_filter']['date_filter_datepicker_range'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Years back and forward'),
+      '#default_value' => $values['date_filter_datepicker_range'] ? $values['date_filter_datepicker_range'] : '-100:+3',
+      '#size' => 10,
+      '#maxsize' => 10,
+      '#description' => t('The range of years displayed in the year drop-down menu. These are either relative to today\'s year ("-nn:+nn"), to the currently selected year ("c-nn:c+nn"), an absolute ("nnnn:nnnn"), or combinations of these formats ("nnnn:-nn"). For more info, check the jQuery UI <a href="!url" target="_blank">datepicker documentation</a>.', array('!url' => 'http://api.jqueryui.com/datepicker/#option-yearRange')),
+      '#states' => array(
+        'visible' => array(
+          ':input[name="date_filter_datepicker_enabled"]' => array('checked' => TRUE)
+        ),
       ),
-    ),
-  );
+    );
+  }
 
   // Permissions.
   $form['options']['permissions_fieldset'] = array(

--- a/includes/common.inc
+++ b/includes/common.inc
@@ -204,6 +204,7 @@ function islandora_solr_prepare_solr_results($solr_results) {
   $highlighting = $solr_results['highlighting'];
   $fields_all = islandora_solr_get_fields('result_fields', FALSE);
   $link_to_object = islandora_solr_get_link_to_object_fields();
+  $date_format = islandora_solr_get_date_format_fields();
 
   // Loop over object results.
   foreach ($object_results as $object_index => $object_result) {
@@ -222,14 +223,21 @@ function islandora_solr_prepare_solr_results($solr_results) {
     }
 
     foreach ($solr_doc as $field => $value) {
-      // Check highlighting.
-      if (isset($highlighting[$pid][$field])) {
-        $value = $highlighting[$pid][$field];
+      // Date formatting.
+      if (isset($date_format[$field])) {
+        $value = format_date(strtotime($value), 'custom', $date_format[$field], 'UTC');
       }
+      // Only apply highlighting when the date isn't formatted.
       else {
-        $value = $solr_doc[$field];
+        // Check highlighting.
+        if (isset($highlighting[$pid][$field])) {
+          $value = $highlighting[$pid][$field];
+        }
+        else {
+          $value = $solr_doc[$field];
+        }
       }
-      // Implode
+      // Implode.
       $value = is_array($value) ? implode(", ", $value) : $value;
       // Add link.
       if (in_array($field, $link_to_object)) {

--- a/includes/common.inc
+++ b/includes/common.inc
@@ -201,7 +201,7 @@ function islandora_solr_prepare_solr_doc($object_results) {
  */
 function islandora_solr_prepare_solr_results($solr_results) {
   $object_results = $solr_results['response']['objects'];
-  $highlighting = $solr_results['highlighting'];
+  $highlighting = isset($solr_results['highlighting']) ? $solr_results['highlighting'] : array();
   $fields_all = islandora_solr_get_fields('result_fields', FALSE);
   $link_to_object = islandora_solr_get_link_to_object_fields();
   $date_format = islandora_solr_get_date_format_fields();

--- a/includes/db.inc
+++ b/includes/db.inc
@@ -153,6 +153,20 @@ function islandora_solr_get_link_to_object_fields() {
 }
 
 /**
+ * Return display fields with 'date format' enabled.
+ */
+function islandora_solr_get_date_format_fields() {
+  $records = islandora_solr_get_fields('result_fields', TRUE, FALSE);
+  $date_format = array();
+  foreach ($records as $key => $value) {
+    if (isset($value['solr_field_settings']['date_format']) && !empty($value['solr_field_settings']['date_format'])) {
+      $date_format[$value['solr_field']] = $value['solr_field_settings']['date_format'];
+    }
+  }
+  return $date_format;
+}
+
+/**
  * Return facet fields with range enabled.
  */
 function islandora_solr_get_range_facets() {

--- a/includes/luke.inc
+++ b/includes/luke.inc
@@ -16,32 +16,25 @@
 function islandora_solr_ping($solr_url) {
   // check for 'http://' or 'https://' prefix
   $solr_url = islandora_solr_check_http($solr_url);
-
   // check for valid url string.
   if (!filter_var($solr_url, FILTER_VALIDATE_URL)) {
     return FALSE;
   }
-
   // split url in host/port/path
   $solr_url_parsed = parse_url($solr_url);
-
   // if it's not a correct url for solr to check, return false.
   if (!isset($solr_url_parsed['host']) || !isset($solr_url_parsed['port'])) {
     return FALSE;
   }
-
   // call solr
   $solr_service = new Apache_Solr_Service($solr_url_parsed['host'], $solr_url_parsed['port'], $solr_url_parsed['path'] . '/');
-
   // ping solr
   $ping = $solr_service->ping();
-
   // if a ping time is returned
   if ($ping) {
     // Add 0.1 ms to the ping time so we never return 0.0.
     return $ping + 0.01;
   }
-
   return FALSE;
 }
 
@@ -55,7 +48,6 @@ function islandora_solr_ping($solr_url) {
  *   include the url with added 'http://' scheme.
  */
 function islandora_solr_check_http($url) {
-
   // check for 'http://' or 'https://' prefix - if not found, add it.
   if (strpos($url, "http://") === FALSE && strpos($url, "https://") === FALSE) {
     $url = 'http://' . $url;
@@ -80,20 +72,16 @@ function islandora_solr_check_http($url) {
  *   returns FALSE.
  */
 function islandora_solr_get_luke($solr_url = NULL, $field = NULL, $num_terms = 0) {
-
   if (!$solr_url) {
     // create url
     $solr_url = variable_get('islandora_solr_url', 'localhost:8080/solr');
   }
-
   // if solr is available get luke
   if (islandora_solr_ping($solr_url)) {
-
     // create url
     $luke_url = $solr_url . '/admin/luke';
     // check for http://
     $luke_url = islandora_solr_check_http($luke_url);
-
     $luke_query = array(
       'wt' => 'json',
       'numTerms' => $num_terms,
@@ -101,16 +89,12 @@ function islandora_solr_get_luke($solr_url = NULL, $field = NULL, $num_terms = 0
     if ($field) {
       $luke_query['fl'] = $field;
     }
-
     // generate nice url
     $luke_url = url($luke_url, array('absolute' => TRUE, 'query' => $luke_query));
-
     // get file content (= json string)
     $luke_json = file_get_contents($luke_url, 0, NULL, NULL);
-
     // decode json to php array
     $luke_array = json_decode($luke_json, TRUE);
-
     return $luke_array;
   }
   else {
@@ -149,7 +133,6 @@ function islandora_solr_get_sortable($solr_url = NULL) {
   if (empty($sortable)) {
     return  FALSE;
   }
-
   return $sortable;
 }
 
@@ -173,7 +156,6 @@ function islandora_solr_check_sortable($solr_url = NULL, $field = NULL) {
     // check if fields are available
     if (!empty($luke['fields'])) {
       $schema = $luke['fields'][$field]['schema'];
-
       // scheck if field is sortable
       // must be indexed and can't be multivalued
       // http://wiki.apache.org/solr/CommonQueryParameters#sort

--- a/includes/query_processor.inc
+++ b/includes/query_processor.inc
@@ -100,7 +100,7 @@ class IslandoraSolrQueryProcessor {
       if (!isset($this->internalSolrParams['sort'])) {
         $this->internalSolrParams['sort'] = variable_get('islandora_solr_base_sort', 'score desc');
         if (trim($this->internalSolrParams['sort']) == '') {
-          $this->internalSolrParams['sort'] = 'score desc'; 
+          $this->internalSolrParams['sort'] = 'score desc';
         }
       }
 
@@ -143,9 +143,6 @@ class IslandoraSolrQueryProcessor {
     // set variables
     $facet_array = islandora_solr_get_fields('facet_fields');
     $facet_fields = implode(",", array_keys($facet_array));
-    $keys = array();
-    $snippet_array = islandora_solr_get_snippet_fields();
-    $snippets = implode(',', $snippet_array);
 
     // set params
     $params_array = array(
@@ -153,11 +150,6 @@ class IslandoraSolrQueryProcessor {
       'facet.mincount' => variable_get('islandora_solr_facet_min_limit', '2'),
       'facet.limit' => variable_get('islandora_solr_facet_max_limit', '20'),
       'qt' => variable_get('islandora_solr_request_handler', ''),
-      'hl' => isset($snippets) ? 'true' : NULL,
-      'hl.fl' => isset($snippets) ? $snippets : NULL,
-      'hl.fragsize' => 400,
-      'hl.simple.pre' => '<span class="islandora-solr-highlight">',
-      'hl.simple.post' => '</span>',
       // Comma separated list configured in the block config.
       'facet.field' => explode(',', $facet_fields),
     );
@@ -198,6 +190,20 @@ class IslandoraSolrQueryProcessor {
       $params_date_facets["facet.date.gap"] = '+1YEAR';
 
       $params_array = array_merge($params_array, $params_date_facets);
+    }
+
+    // Highlighting.
+    $highlighting_array = islandora_solr_get_snippet_fields();
+    if (!empty($highlighting_array)) {
+      $highlights = implode(',', $highlighting_array);
+      $highlighting_params = array(
+        'hl' => isset($highlights) ? 'true' : NULL,
+        'hl.fl' => isset($highlights) ? $highlights : NULL,
+        'hl.fragsize' => 400,
+        'hl.simple.pre' => '<span class="islandora-solr-highlight">',
+        'hl.simple.post' => '</span>',
+      );
+      $params_array += $highlighting_params;
     }
 
     // add parameters

--- a/includes/query_processor.inc
+++ b/includes/query_processor.inc
@@ -96,14 +96,6 @@ class IslandoraSolrQueryProcessor {
       // set base query
       $this->internalSolrQuery = variable_get('islandora_solr_base_query', 'timestamp:[* TO NOW]');
 
-      // set base sort if empty
-      if (!isset($this->internalSolrParams['sort'])) {
-        $this->internalSolrParams['sort'] = variable_get('islandora_solr_base_sort', 'score desc');
-        if (trim($this->internalSolrParams['sort']) == '') {
-          $this->internalSolrParams['sort'] = 'score desc';
-        }
-      }
-
       // we must also undo dismax if it's been set
       $this->solrDefType = NULL;
       $this->solrParams['defType'] = NULL;
@@ -119,6 +111,13 @@ class IslandoraSolrQueryProcessor {
       else {
         // use ascending
         $this->solrParams['sort'] = $sort_explode[0] . ' asc';
+      }
+    }
+    else {
+      $base_sort = variable_get('islandora_solr_base_sort', '');
+      $base_sort = trim($base_sort);
+      if (!empty($base_sort)) {
+        $this->solrParams['sort'] = $base_sort;
       }
     }
 

--- a/includes/query_processor.inc
+++ b/includes/query_processor.inc
@@ -184,6 +184,10 @@ class IslandoraSolrQueryProcessor {
         if ($gap) {
           $params_date_facets["f.{$field}.facet.date.gap"] = $gap;
         }
+        // When the range slider is enabled we always want to return empty values.
+        if ($value['solr_field_settings']['range_facet_slider_enabled'] == 1) {
+          $params_date_facets["f.{$field}.facet.mincount"] = 0;
+        }
         // remove range/date field from facet.field array
         $pos = array_search($field, $params_array['facet.field']);
         unset($params_array['facet.field'][$pos]);

--- a/includes/results.inc
+++ b/includes/results.inc
@@ -633,9 +633,9 @@ class IslandoraSolrFacets {
    */
   public static function init($islandoraSolrQuery) {
     self::$islandoraSolrQuery = $islandoraSolrQuery;
-    self::$facet_fields = self::getFacetFields();
-    self::$facet_dates = self::getFacetDates();
-    self::$facet_ranges = self::getFacetRanges(); // not in place yet.
+    self::$facet_fields = $islandoraSolrQuery->islandoraSolrResult['facet_counts']['facet_fields'];
+    self::$facet_dates = $islandoraSolrQuery->islandoraSolrResult['facet_counts']['facet_dates'];
+    self::$facet_ranges = $islandoraSolrQuery->islandoraSolrResult['facet_counts']['facet_ranges']; // not in place yet.
 
     self::$facet_fields_settings = islandora_solr_get_fields('facet_fields', TRUE, FALSE, TRUE); // filtered, not simplified and fields as keys
     self::$facet_fields_settings_simple = _islandora_solr_simplify_fields(self::$facet_fields_settings);
@@ -646,33 +646,6 @@ class IslandoraSolrFacets {
     // Calculate variable date gap.
     // @XXX move elsewhere?
     self::variableDateGap();
-  }
-
-  /**
-   * Returns an array with the facet results.
-   */
-  public static function getFacetFields() {
-    $facet_fields = isset(self::$islandoraSolrQuery->islandoraSolrResult['facet_counts']['facet_fields']) ? self::$islandoraSolrQuery->islandoraSolrResult['facet_counts']['facet_fields'] : array();
-    $facet_fields_json  = json_encode($facet_fields);
-    return json_decode($facet_fields_json, TRUE);
-  }
-
-  /**
-   * Returns an array with the date facet results.
-   */
-  public static function getFacetDates() {
-    $facet_dates = isset(self::$islandoraSolrQuery->islandoraSolrResult['facet_counts']['facet_dates']) ? self::$islandoraSolrQuery->islandoraSolrResult['facet_counts']['facet_dates'] : array();
-    $facet_dates_json  = json_encode($facet_dates);
-    return json_decode($facet_dates_json, TRUE);
-  }
-
-  /**
-   * Returns an array with the range facet results.
-   */
-  public static function getFacetRanges() {
-    $facet_ranges = isset(self::$islandoraSolrQuery->islandoraSolrResult['facet_counts']['facet_ranges']) ? self::$islandoraSolrQuery->islandoraSolrResult['facet_counts']['facet_ranges'] : array();
-    $facet_ranges_json  = json_encode($facet_ranges);
-    return json_decode($facet_ranges_json, TRUE);
   }
 
   /**
@@ -1056,11 +1029,11 @@ class IslandoraSolrFacets {
     // @TODO: date_format configurable.
     $gap = NULL;
     $date_format = 'Y';
-    if ($calc_total_days == 1) {
+    if ($calc_total_days < 7) {
       $gap = t('days');
       $date_format = 'M j, Y';
     }
-    elseif ($calc_total_days == 7) {
+    elseif ($calc_total_days >= 7 && $calc_total_days <= 28) {
       $gap = t('weeks');
       $date_format = 'M j, Y';
     }
@@ -1211,7 +1184,6 @@ class IslandoraSolrFacets {
     $facet_dates = self::$facet_dates;
     // populate with terms that needed a second solr call to update facets
     $needs_solr_call = array();
-
     // loop over all date facets
     foreach ($facet_dates as $solr_field => $buckets) {
       $values = array();

--- a/includes/results.inc
+++ b/includes/results.inc
@@ -16,12 +16,14 @@ class IslandoraSolrResults {
   public $resultFieldArray = array();
   public $allSubsArray = array();
   public $islandoraSolrQueryProcessor;
+  public $rangeFacets = array();
 
   /**
    * Constructor
    */
   function IslandoraSolrResults() {
     $this->prepFieldSubstitutions();
+    $this->rangeFacets = islandora_solr_get_range_facets();
   }
 
   /**
@@ -170,7 +172,6 @@ class IslandoraSolrResults {
    *   Rendered lists of the currently active query and/or filters.
    */
   function currentQuery($islandoraSolrQuery) {
-
     // set path
     $path = SOLR_SEARCH_PATH . '/' . replace_slashes($islandoraSolrQuery->solrQuery);
     // get date format
@@ -181,18 +182,12 @@ class IslandoraSolrResults {
     $fq = isset($islandoraSolrQuery->internalSolrParams['f']) ? $islandoraSolrQuery->internalSolrParams['f'] : array();
     // parameters set in url
     $params = $islandoraSolrQuery->internalSolrParams;
-    // get range facets
-    $range_facets = islandora_solr_get_range_facets();
-
-
     // Get Query values
     if (!in_array($islandoraSolrQuery->solrQuery, $islandoraSolrQuery->different_kinds_of_nothing)) {
       // get query value
       $query_value = $islandoraSolrQuery->solrQuery;
-
       // set list variables
       $query_list = array();
-
       // remove link keeps all parameters (query gets removed instead)
       $query_minus = array();
       $query_minus = $params;
@@ -222,13 +217,10 @@ class IslandoraSolrResults {
 
     }
 
-
     // Get Filter values
     if (!empty($fq)) {
-
       // set list variables
       $filter_list = array();
-
       // loop over filters
       foreach ($fq as $key => $filter) {
 
@@ -240,9 +232,7 @@ class IslandoraSolrResults {
         else {
           $symbol = '=';
         }
-
-        $filter_string = $this->formatFilter($filter);
-
+        $filter_string = $this->formatFilter($filter, $islandoraSolrQuery);
         // pull out filter (for exclude link)
         $query_minus = array();
         $f_x['f'] = array_diff($params['f'], array($filter));
@@ -255,7 +245,6 @@ class IslandoraSolrResults {
         if (empty($query_minus['f'])) {
           unset($query_minus['f']);
         }
-
         // set attributes variable for remove link
         $attr_minus = array();
         // set title
@@ -266,7 +255,6 @@ class IslandoraSolrResults {
         $attr_minus['rel'] = 'nofollow';
         // set url
         $attr_minus['href'] = url($path, array('query' => $query_minus));
-
         // create link
         // we're not using l() because of active classes: http://drupal.org/node/41595
         $filter_list[] = '<a' . drupal_attributes($attr_minus) . '>(-)</a> ' . $symbol . ' ' . check_plain($filter_string);
@@ -294,8 +282,6 @@ class IslandoraSolrResults {
     $format = variable_get('islandora_solr_facet_date_format', 'Y');
     // set breadcrumb variable
     $breadcrumb = array();
-    // get range facets
-    $range_facets = islandora_solr_get_range_facets();
     // get user provided filter parameters
     if (isset($islandoraSolrQuery->internalSolrParams['f'])) {
       $fq = $islandoraSolrQuery->internalSolrParams['f'];
@@ -316,15 +302,12 @@ class IslandoraSolrResults {
       // set var
       $f['f'] = array();
       foreach ($fq as $key => $filter) {
-
         // check for exclude filter
         $exclude = FALSE;
         if ($filter[0] == '-') {
           $exclude = TRUE;
         }
-
-        $filter_string = $this->formatFilter($filter);
-
+        $filter_string = $this->formatFilter($filter, $islandoraSolrQuery);
         // increment filter array with current filter (for breadcrumb link)
         $query = array();
         $query_diff = array_diff($params, array('f' => array()));
@@ -371,7 +354,6 @@ class IslandoraSolrResults {
               . '<span class="islandora-solr-breadcrumb-super"> <a' . drupal_attributes($attr_x) . '>(' . t('x') . ')</a></span>';
 
       }
-
       // at this point reverse the breadcrumbs array (only contains filters)
       $breadcrumb = array_reverse($breadcrumb);
     }
@@ -380,21 +362,17 @@ class IslandoraSolrResults {
     if (!in_array($islandoraSolrQuery->solrQuery, $islandoraSolrQuery->different_kinds_of_nothing)) {
       // get query value
       $query_value = $islandoraSolrQuery->solrQuery;
-
       // remove all filters for this breadcrumb
       $query = array();
       $query = array_diff($params, array('f' => array()));
-
       // remove button keeps all parameters (query gets removed instead)
       $query_x = array();
       $query_x = $params;
       if (empty($params['f'])) {
         unset($query_x['f']);
       }
-
       // remove query from path
       $path_x = implode('/', explode('/', $path, -1)) . '/ ';
-
       // set attributes variable
       $attr = array();
       // set title
@@ -454,10 +432,12 @@ class IslandoraSolrResults {
    *
    * @param string $filter
    *   The passed in filter.
+   * @param object $islandoraSolrQuery
+   *   The current Solr Query
    * @return string
    *   The formatted filter string for breadcrumbs and active query.
    */
-  function formatFilter($filter) {
+  function formatFilter($filter, $islandoraSolrQuery) {
     // Check if there are operators in the filter.
     // @TODO: See how this interacts with multiple date filters.
     $fq_split = preg_split('/ (OR|AND) /', $filter);
@@ -484,11 +464,10 @@ class IslandoraSolrResults {
       $filter_split = explode(':', $filter, 2);
       // trim brackets
       $filter_split[1] = trim($filter_split[1], "\"");
-
       // if value is date
       if (isset($islandoraSolrQuery->solrParams['facet.date']) && in_array(ltrim($filter_split[0], '-'), $islandoraSolrQuery->solrParams['facet.date'])) {
         // check date format setting
-        foreach ($range_facets as $value) {
+        foreach ($this->rangeFacets as $value) {
           if ($value['solr_field'] == $filter_split[0] && isset($value['solr_field_settings']['date_facet_format']) && !empty($value['solr_field_settings']['date_facet_format'])) {
             $format = $value['solr_field_settings']['date_facet_format'];
           }

--- a/islandora_solr.module
+++ b/islandora_solr.module
@@ -54,13 +54,31 @@ function islandora_solr_menu() {
     'type' => MENU_CALLBACK,
   );
   $items['admin/islandora/search/islandora_solr'] = array(
-    'title' => 'Solr Client',
+    'title' => 'Solr index',
+    'description' => 'Configure Solr index.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('islandora_solr_admin_index_settings'),
+    'access arguments' => array('administer islandora solr'),
+    'file' => 'includes/admin.inc',
+    'type' => MENU_NORMAL_ITEM,
+  );
+  $items['admin/islandora/search/islandora_solr/index'] = array(
+    'title' => 'Solr index',
+    'description' => 'Configure Solr index.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('islandora_solr_admin_index_settings'),
+    'access arguments' => array('administer islandora solr'),
+    'file' => 'includes/admin.inc',
+    'type' => MENU_DEFAULT_LOCAL_TASK,
+  );
+  $items['admin/islandora/search/islandora_solr/settings'] = array(
+    'title' => 'Solr settings',
     'description' => 'Configure Solr search settings.',
     'page callback' => 'drupal_get_form',
     'page arguments' => array('islandora_solr_admin_settings'),
     'access arguments' => array('administer islandora solr'),
     'file' => 'includes/admin.inc',
-    'type' => MENU_NORMAL_ITEM,
+    'type' => MENU_LOCAL_TASK,
   );
   $items['islandora_solr/field'] = array(
     'title' => 'Result field',


### PR DESCRIPTION
- Fix for broken date range sliders: every date range field that has the slider enabled, set the minimum facet results to 0 so we always return empty dates as well. This fixed the date range calculation as well though a small fix needed to applied.
- Showing date range settings made dependent on the Solr field being a 'date' type. This will need to updated when we want to use integers for our range facets.
- Fixed the way default sort fields are applied.
- Added possibility to format date fields in Solr results.
- Don't include highlighting Solr parameters if no fields are set to be highlighted. This would slow Solr calls down.
- Fixed minor date range values formatting in breadcrumbs and current query.
