### PR TITLE
Fixed bizarre php bug(?) where not all keywords were being copied into ...

### DIFF
--- a/includes/db.inc
+++ b/includes/db.inc
@@ -62,8 +62,8 @@ function islandora_solr_get_fields($field_type = NULL, $filter = TRUE, $simplifi
   if ($keys == TRUE && $simplified == FALSE) {
     $original = $records;
     $records = array();
-    foreach ($original as $value) {
-      $records[$value['solr_field']] = $value;
+    foreach ($original as $field) {
+      $records[$field['solr_field']] = $field;
     }
   }
   return $records;


### PR DESCRIPTION
...the results array. See similar problem here: http://stackoverflow.com/questions/775463/ignorance-or-bug-on-phps-foreach-construct

It would appear that having defined $value as being a reference variable above, using it again in the foreach loop was a bad plan - causing the original array $original to actually be modified during the foreach loop.

I changed the name of the variable. It solved the problem.
