### PR TITLE
Replaces solr field names with query field labels in Current Query

### DIFF
--- a/includes/results.inc
+++ b/includes/results.inc
@@ -204,6 +204,11 @@ class IslandoraSolrResults {
     if (!in_array($islandora_solr_query->solrQuery, $islandora_solr_query->differentKindsOfNothing)) {
       // Get query value.
       $query_value = $islandora_solr_query->solrQuery;
+
+      // Replace field names in query value.
+      foreach ($this->searchFieldArray as $search_field => $search_field_label) {
+        $query_value = str_replace($search_field . ':(', $search_field_label . ':(', $query_value);
+      }
       $query_list = array();
 
       // Remove link keeps all parameters (query gets removed instead).


### PR DESCRIPTION
This is ugly. Labels are nicer.
![screen shot 2013-07-10 at 5 18 03 pm](https://f.cloud.github.com/assets/1943338/778284/4f819cae-e9ac-11e2-9520-3c4d234ddaa5.jpg)
