### PR TITLE
Results paging with grid display

### DIFF
--- a/includes/query_processor.inc
+++ b/includes/query_processor.inc
@@ -283,10 +283,8 @@ class IslandoraSolrQueryProcessor {
     // The hook implementation needs to specify that it takes a reference.
     module_invoke_all('islandora_solr_query', $this);
 
-    /**
-     * Reset solrStart incase the number of results (ie. $this->solrLimit) is
-     * modified.
-     */
+    // Reset solrStart incase the number of results (ie. $this->solrLimit) is
+    // modified.
     $this->solrStart = max(0, $start_page) * $this->solrLimit;
   }
 

--- a/includes/query_processor.inc
+++ b/includes/query_processor.inc
@@ -282,6 +282,12 @@ class IslandoraSolrQueryProcessor {
     // Invoke a hook for third-party modules to alter the parameters.
     // The hook implementation needs to specify that it takes a reference.
     module_invoke_all('islandora_solr_query', $this);
+    
+		/**
+     * Reset solrStart incase the number of results (ie. $this->solrLimit) is modified.
+     */
+		// Set solr start.
+    $this->solrStart = max(0, $start_page) * $this->solrLimit;
   }
 
   /**

--- a/includes/query_processor.inc
+++ b/includes/query_processor.inc
@@ -282,11 +282,11 @@ class IslandoraSolrQueryProcessor {
     // Invoke a hook for third-party modules to alter the parameters.
     // The hook implementation needs to specify that it takes a reference.
     module_invoke_all('islandora_solr_query', $this);
-    
-		/**
-     * Reset solrStart incase the number of results (ie. $this->solrLimit) is modified.
+
+    /**
+     * Reset solrStart incase the number of results (ie. $this->solrLimit) is
+     * modified.
      */
-		// Set solr start.
     $this->solrStart = max(0, $start_page) * $this->solrLimit;
   }
 


### PR DESCRIPTION
For some reason using the grid display we were getting the last 4 results from every page displaying as the first 4 on the next page of search results.

I seems to be the module_invoke_all('islandora_solr_query',$this);

The $this->solrStart is set before it, but this call was calling

islandora_solr_config_islandora_solr_query() and it was modifying the $this->solrLimit amount.

ie. 
$this->solrLimit = 20, then page 2 makes $this->solrStart = 20. 

But then $this->solrLimit changed to 24 (due to a grid layout).

So page 1 displays 0 - 24, but page 2 displays 20 - 44, and page 3 displays 40 - 64, etc.

Feel free to dump this merge and fix it yourselves. But this solved it for me.

cheers,
jared
