### PR TITLE
Change default query to *:*, add an alter.

### DIFF
--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -497,7 +497,7 @@ function islandora_solr_admin_settings($form, &$form_state) {
       Setting a useful default query allows the use of Solr to browse without having to enter a query.
       This may be used in conjunction with a background filter below.<br />
       Consider using <strong>timestamp:[* TO NOW]</strong> or <strong>*:*</strong><br />'),
-    '#default_value' => variable_get('islandora_solr_base_query', 'timestamp:[* TO NOW]'),
+    '#default_value' => variable_get('islandora_solr_base_query', '*:*'),
   );
   $form['islandora_solr_tabs']['query_defaults']['islandora_solr_base_sort'] = array(
     '#type' => 'textfield',

--- a/includes/query_processor.inc
+++ b/includes/query_processor.inc
@@ -125,7 +125,7 @@ class IslandoraSolrQueryProcessor {
       // So we can allow empty queries to dismax.
       $this->solrQuery = ' ';
       // Set base query.
-      $this->internalSolrQuery = variable_get('islandora_solr_base_query', 'timestamp:[* TO NOW]');
+      $this->internalSolrQuery = variable_get('islandora_solr_base_query', '*:*');
 
       // We must also undo dismax if it has been set.
       $this->solrDefType = NULL;
@@ -282,6 +282,7 @@ class IslandoraSolrQueryProcessor {
     // Invoke a hook for third-party modules to alter the parameters.
     // The hook implementation needs to specify that it takes a reference.
     module_invoke_all('islandora_solr_query', $this);
+    drupal_alter('islandora_solr_query', $this);
   }
 
   /**

--- a/islandora_solr.api.php
+++ b/islandora_solr.api.php
@@ -99,6 +99,20 @@ function hook_islandora_solr_query($islandora_solr_query) {
 }
 
 /**
+ * Alter which is called directly after hook_islandora_solr_query().
+ *
+ * @param IslandoraSolrQueryProcessor $islandora_solr_query
+ *   The IslandoraSolrQueryProcessor object which includes the current query
+ *   settings but at the end of IslandoraSolrQuery::buildQuery().
+ *
+ * @see hook_islandora_solr_query()
+ * @see IslandoraSolrQueryProcessor::buildQuery()
+ */
+function hook_islandora_solr_query_alter($islandora_solr_query) {
+
+}
+
+/**
  * Hook to collect data to populate block Islandora Solr blocks.
  *
  * Note: it is valid to specify *either* a class and method *or* a form. The


### PR DESCRIPTION
Using the former default, timestamp:[\* TO NOW], Solr was highlighting random things because it was interpreting the default query as a date.
