### PR TITLE
Fix enclosure url error when used in conjunction with @rosiel's islandor...

### DIFF
--- a/islandora_solr_config/includes/rss_results.inc
+++ b/islandora_solr_config/includes/rss_results.inc
@@ -2,13 +2,13 @@
 
 /**
  * @file
- * Contains methods to search solr and display results.  depends on 
+ * Contains methods to search solr and display results.  depends on
  * Apache_Solr_Php client.
  */
 
 /**
  * Extention of IslandoraSolrResults for templating purposes.
- * This overrides the displayResults function to provide an alternate display 
+ * This overrides the displayResults function to provide an alternate display
  * type.
  */
 
@@ -16,7 +16,7 @@ class IslandoraSolrResultsRSS extends IslandoraSolrResults {
 
   /**
    * Outputs results basically in the normal way.
-   * 
+   *
    * Thumbnails pulled from the Fedora repository.
    *
    * @param object $islandora_solr_query
@@ -89,7 +89,7 @@ class IslandoraSolrResultsRSS extends IslandoraSolrResults {
    * Function for setting the values of the <item> elements for the RSS display.
    *
    * @tutorial http://feed2.w3.org/docs/rss2.html#hrelementsOfLtitemgt
-   * 
+   *
    * @return array
    *   variable that holds all values to be rendered into <item> elements
    */
@@ -115,7 +115,7 @@ class IslandoraSolrResultsRSS extends IslandoraSolrResults {
     $is_datastream = in_array($dsid, $doc['datastreams']);
 
     if ($is_datastream) {
-      $enclosure_url = $object_url . '/datastream/' . $dsid;
+      $enclosure_url = $base_url . '/islandora/object/' . $doc['PID'] . '/Datastream/' . $dsid;
     }
 
     $rss_source = variable_get('site_name', "Default site name");
@@ -162,7 +162,7 @@ class IslandoraSolrResultsRSS extends IslandoraSolrResults {
    * Function to set values of the <channel> elements for the RSS display.
    *
    * @tutorial http://feed2.w3.org/docs/rss2.html#requiredChannelElements
-   * 
+   *
    * @return array
    *   variable that holds all values to be rendered into <channel> elements
    */


### PR DESCRIPTION
...a_pathauto

I noticed that when using @rosiel's islandora_pathauto in conjunction with this, the way the $enclosure_url was being declared previously just added on to the rewritten url, resulting in a 404 to the dsid. This solution should guarantee hitting the dsid.
