### PR TITLE
General usability.

### DIFF
--- a/includes/blocks.inc
+++ b/includes/blocks.inc
@@ -176,14 +176,17 @@ function islandora_solr_simple_search_form($form, &$form_state) {
  *   An associative array containing form state.
  */
 function islandora_solr_simple_search_form_submit($form, &$form_state) {
-  $form_state['rebuild'] = TRUE;
-  $search_string = $form_state['values']['islandora_simple_search_query'];
-  // XXX: Shouldn't this use islandora_solr_replace_string()?
-  $search_string = str_replace('/', '~slsh~', $search_string);
+  module_load_include('inc', 'islandora_solr', 'includes/utilities');
+  $search_string = islandora_solr_replace_slashes($form_state['values']['islandora_simple_search_query']);
 
   $query = array('type' => 'dismax');
 
-  drupal_goto('islandora/search/' . $search_string, array('query' => $query));
+  $form_state['redirect'] = array(
+    ISLANDORA_SOLR_SEARCH_PATH . "/$search_string",
+    array(
+      'query' => $query,
+    ),
+  );
 }
 
 /**
@@ -411,8 +414,7 @@ function islandora_solr_advanced_search_form_submit($form, &$form_state) {
   foreach ($form_state['values']['terms'] as $term) {
     $field = $term['field'];
     $search = trim($term['search']);
-    // XXX: Should probably use islandora_solr_replace_slashes().
-    $search = str_replace('/', '~slsh~', $search);
+    $search = islandora_solr_replace_slashes($search);
     $boolean = (isset($term['boolean'])) ? $term['boolean'] : variable_get('islandora_solr_search_boolean', 'user');
     $field = islandora_solr_lesser_escape($field);
     // Add query.
@@ -441,7 +443,7 @@ function islandora_solr_advanced_search_form_submit($form, &$form_state) {
   }
 
   // Navigate to results page.
-  drupal_goto('islandora/search/' . $query);
+  $form_state['redirect'] = ISLANDORA_SOLR_SEARCH_PATH . "/$query";
 }
 
 /**
@@ -466,7 +468,7 @@ function islandora_solr_display() {
 
     // Parameters set in URL.
     $params = isset($_islandora_solr_queryclass->internalSolrParams) ? $_islandora_solr_queryclass->internalSolrParams : array();
-    $path = ISLANDORA_SOLR_SEARCH_PATH . '/' . islandora_solr_replace_slashes($_islandora_solr_queryclass->solrQuery);
+    $path = current_path();
 
     $profiles = module_invoke_all("islandora_solr_primary_display");
     // Get the table settings.
@@ -551,7 +553,7 @@ function islandora_solr_sort() {
     // Parameters set in URL.
     $params = isset($_islandora_solr_queryclass->internalSolrParams) ? $_islandora_solr_queryclass->internalSolrParams : array();
 
-    $path = ISLANDORA_SOLR_SEARCH_PATH . '/' . islandora_solr_replace_slashes($_islandora_solr_queryclass->solrQuery);
+    $path = current_path();
 
     $sort_terms = islandora_solr_get_fields('sort_fields');
 

--- a/includes/facets.inc
+++ b/includes/facets.inc
@@ -184,7 +184,7 @@ function islandora_solr_date_filter_form_submit($form, &$form_state) {
 
   $form_state['rebuild'] = TRUE;
   $params = isset($_islandora_solr_queryclass->internalSolrParams) ? $_islandora_solr_queryclass->internalSolrParams : array();
-  $path = ISLANDORA_SOLR_SEARCH_PATH . '/' . islandora_solr_replace_slashes($_islandora_solr_queryclass->solrQuery);
+  $path = current_path();
   $facet_field = $form_state['values']['date_filter_facet_field'];
   $form_key = $form_state['triggering_element']['#form_key'];
 
@@ -330,7 +330,7 @@ function islandora_solr_range_slider_form_submit($form, &$form_state) {
   // Set variables.
   global $_islandora_solr_queryclass;
   $params = isset($_islandora_solr_queryclass->internalSolrParams) ? $_islandora_solr_queryclass->internalSolrParams : array();
-  $path = ISLANDORA_SOLR_SEARCH_PATH . '/' . islandora_solr_replace_slashes($_islandora_solr_queryclass->solrQuery);
+  $path = current_path();
   $form_key = $form_state['triggering_element']['#form_key'];
 
   $term = $form_state['values']['range_slider_term'];

--- a/includes/query_processor.inc
+++ b/includes/query_processor.inc
@@ -118,7 +118,7 @@ class IslandoraSolrQueryProcessor {
 
     // XXX: Fix the query as some characters will break the search : and / are
     // examples.
-    $this->solrQuery = urldecode(islandora_solr_restore_slashes($query));
+    $this->solrQuery = islandora_solr_restore_slashes(urldecode($query));
 
     // If the query is empty.
     if (empty($this->solrQuery) || in_array($this->solrQuery, $this->differentKindsOfNothing)) {

--- a/includes/results.inc
+++ b/includes/results.inc
@@ -111,7 +111,7 @@ class IslandoraSolrResults {
     $secondary_display_profiles = module_invoke_all('islandora_solr_secondary_display');
 
     // $_GET['q'] didn't seem to work here.
-    $path = ISLANDORA_SOLR_SEARCH_PATH . '/' . islandora_solr_replace_slashes($islandora_solr_query->solrQuery);
+    $path = current_path();
 
     // Parameters set in URL.
     $params = $islandora_solr_query->internalSolrParams;
@@ -191,7 +191,7 @@ class IslandoraSolrResults {
    */
   public function currentQuery($islandora_solr_query) {
     $output = '';
-    $path = ISLANDORA_SOLR_SEARCH_PATH . '/' . islandora_solr_replace_slashes($islandora_solr_query->solrQuery);
+    $path = current_path();
 
     $format = variable_get('islandora_solr_facet_date_format', 'Y');
 
@@ -300,7 +300,7 @@ class IslandoraSolrResults {
    */
   public function setBreadcrumbs($islandora_solr_query) {
     // $_GET['q'] didn't seem to work here.
-    $path = ISLANDORA_SOLR_SEARCH_PATH . '/' . islandora_solr_replace_slashes($islandora_solr_query->solrQuery);
+    $path = current_path();
     // Get date format.
     $format = variable_get('islandora_solr_facet_date_format', 'Y');
 
@@ -915,7 +915,7 @@ class IslandoraSolrFacets {
       }
       // Current path including query, for example islandora/solr/query.
       // $_GET['q'] didn't seem to work here.
-      $path = ISLANDORA_SOLR_SEARCH_PATH . '/' . islandora_solr_replace_slashes($islandora_solr_query->solrQuery);
+      $path = current_path();
       // Parameters set in URL.
       $params = $islandora_solr_query->internalSolrParams;
       // Set filter key if there are no filters included.

--- a/islandora_solr_config/includes/csv_results.inc
+++ b/islandora_solr_config/includes/csv_results.inc
@@ -31,7 +31,7 @@ class IslandoraSolrResultsCSV extends IslandoraSolrResults {
     // We want to unset the display profile of CSV, but keep everything else.
     $params = $redirect['query'];
     unset($params['solr_profile']);
-    $redirect_url = "islandora/search/$islandora_solr_query->solrQuery";
+    $redirect_url = current_path();
     batch_set($this->batchSolrResults($islandora_solr_query));
     batch_process(array(
       $redirect_url,


### PR DESCRIPTION
Blocks are now useful when the `islandora_solr()` display is present on other pages.
