### PR TITLE
Updates for grid display

### DIFF
--- a/islandora_solr_config/includes/grid_results.inc
+++ b/islandora_solr_config/includes/grid_results.inc
@@ -28,7 +28,9 @@ class IslandoraSolrResultsGrid extends IslandoraSolrResults {
   public function printResults($solr_results) {
     $mod_path = drupal_get_path('module', 'islandora_solr_config');
     drupal_add_css("$mod_path/css/islandora_solr_config.theme.css");
+    $solr_results = islandora_solr_prepare_solr_results($solr_results);
     $object_results = $solr_results['response']['objects'];
+    $object_results = islandora_solr_prepare_solr_doc($object_results);
 
     $elements = array();
     $elements['solr_total'] = $solr_results['response']['numFound'];

--- a/islandora_solr_config/islandora_solr_config.module
+++ b/islandora_solr_config/islandora_solr_config.module
@@ -72,15 +72,18 @@ function islandora_solr_config_menu() {
   );
   return $items;
 }
+
 /**
  * Implements hook_theme().
  */
 function islandora_solr_config_theme() {
   $path = drupal_get_path('module', 'islandora_solr_config');
+  $file = 'theme.inc';  
 
   return array(
     'islandora_solr_grid' => array(
       'path' => $path . '/theme',
+      'file' => $file,
       'template' => 'islandora-solr-grid',
       'variables' => array('results' => NULL, 'elements' => array()),
     ),

--- a/islandora_solr_config/theme/islandora-solr-grid.tpl.php
+++ b/islandora_solr_config/theme/islandora-solr-grid.tpl.php
@@ -28,6 +28,11 @@
           ?>
         </dt>
         <?php foreach($result['solr_doc'] as $key => $value): ?>
+          <?php if ($key != $value['label']): ?>
+            <dt class="solr-label <?php print $value['class']; ?>">
+              <?php print $value['label']; ?>
+            </dt>
+          <?php endif; ?>
           <dd class="solr-grid-caption <?php print $value['class']; ?>">
             <?php print $value['value']; ?>
           </dd>

--- a/islandora_solr_config/theme/islandora-solr-grid.tpl.php
+++ b/islandora_solr_config/theme/islandora-solr-grid.tpl.php
@@ -27,15 +27,11 @@
             ));
           ?>
         </dt>
-        <dd class="solr-grid-caption">
-          <?php
-            $object_label = isset($result['object_label']) ? $result['object_label'] : '';
-            print l($object_label, $result['object_url'], array(
-              'query' => $result['object_url_params'],
-              'fragment' => isset($result['object_url_fragment']) ? $result['object_url_fragment'] : '',
-            ));
-          ?>
-        </dd>
+        <?php foreach($result['solr_doc'] as $key => $value): ?>
+          <dd class="solr-grid-caption <?php print $value['class']; ?>">
+            <?php print $value['value']; ?>
+          </dd>
+        <?php endforeach; ?>
       </dl>
     <?php endforeach; ?>
     </div>

--- a/islandora_solr_config/theme/theme.inc
+++ b/islandora_solr_config/theme/theme.inc
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @file
+ * Theme functions for the Islandora Solr Search Config module.
+ */
+
+/**
+ * Prepares variables for islandora_solr_config templates.
+ *
+ * Default template: theme/islandora-solr-grid.tpl.php.
+ */
+function islandora_solr_config_preprocess_islandora_solr_grid(&$variables) {
+  $results = $variables['results'];
+  foreach ($results as $key => $result) {
+    // Thumbnail.
+    $path = url($result['thumbnail_url'], array('query' => $result['thumbnail_url_params']));
+    $image = theme('image', array('path' => $path));
+
+    $options = array('html' => TRUE);
+    if (isset($result['object_label'])) {
+      $options['attributes']['title'] = $result['object_label'];
+    }
+    if (isset($result['object_url_params'])) {
+      $options['query'] = $result['object_url_params'];
+    }
+    if (isset($result['object_url_fragment'])) {
+      $options['fragment'] = $result['object_url_fragment'];
+    }
+    // Thumbnail link.
+    $variables['results'][$key]['thumbnail'] = l($image, $result['object_url'], $options);
+  }
+}


### PR DESCRIPTION
These changes allow the grid display to respect the Default display settings under Solr settings. The Display fields are all used instead of just the title. The labels are only printed if they have been customized.
