### PR TITLE
Updates for grid display

### DIFF
--- a/islandora_solr_config/includes/grid_results.inc
+++ b/islandora_solr_config/includes/grid_results.inc
@@ -28,7 +28,9 @@ class IslandoraSolrResultsGrid extends IslandoraSolrResults {
   public function printResults($solr_results) {
     $mod_path = drupal_get_path('module', 'islandora_solr_config');
     drupal_add_css("$mod_path/css/islandora_solr_config.theme.css");
+    $solr_results = islandora_solr_prepare_solr_results($solr_results);
     $object_results = $solr_results['response']['objects'];
+    $object_results = islandora_solr_prepare_solr_doc($object_results);
 
     $elements = array();
     $elements['solr_total'] = $solr_results['response']['numFound'];

--- a/islandora_solr_config/theme/islandora-solr-grid.tpl.php
+++ b/islandora_solr_config/theme/islandora-solr-grid.tpl.php
@@ -27,15 +27,16 @@
             ));
           ?>
         </dt>
-        <dd class="solr-grid-caption">
-          <?php
-            $object_label = isset($result['object_label']) ? $result['object_label'] : '';
-            print l($object_label, $result['object_url'], array(
-              'query' => $result['object_url_params'],
-              'fragment' => isset($result['object_url_fragment']) ? $result['object_url_fragment'] : '',
-            ));
-          ?>
-        </dd>
+        <?php foreach($result['solr_doc'] as $key => $value): ?>
+          <?php if ($key != $value['label']): ?>
+            <dt class="solr-label <?php print $value['class']; ?>">
+              <?php print $value['label']; ?>
+            </dt>
+          <?php endif; ?>
+          <dd class="solr-grid-caption <?php print $value['class']; ?>">
+            <?php print $value['value']; ?>
+          </dd>
+        <?php endforeach; ?>
       </dl>
     <?php endforeach; ?>
     </div>


### PR DESCRIPTION
Running the grid display results through the utility functions and updating the template allows it to use the fields defined in Default display settings under Solr settings.
