### PR TITLE
Controllable character truncation on Display Fields

### DIFF
--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -1518,6 +1518,8 @@ function _islandora_solr_handle_solr_field_settings($solr_field_settings = NULL,
           'link_rendering' => $solr_field_settings['link_rendering'],
           'snippet' => isset($solr_field_settings['snippet']) ? $solr_field_settings['snippet'] : NULL,
           'date_format' => isset($solr_field_settings['date_format']) ? trim($solr_field_settings['date_format']) : '',
+          'maximum_length' => isset($solr_field_settings['maximum_length']) ? trim($solr_field_settings['maximum_length']) : '',
+          'truncation_suffix' => isset($solr_field_settings['truncation_suffix']) ? rtrim($solr_field_settings['truncation_suffix']) : '',
           'permissions' => empty($solr_field_settings['enable_permissions']) ? FALSE : $solr_field_settings['permissions'],
         );
         break;
@@ -1732,6 +1734,27 @@ function islandora_solr_admin_settings_result_fields($form, &$form_state, $varia
       '#description' => t('The format of the date, as it will be displayed in the search results. Use <a href="!url" target="_blank">PHP date()</a> formatting.', array('!url' => 'http://php.net/manual/function.date.php')),
     );
   }
+
+  $form['options']['max_length_fieldset'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Maximum Length'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+    'maximum_length' => array(
+      '#type' => 'textfield',
+      '#title' => t('Maximum Length'),
+      '#default_value' => isset($values['maximum_length']) ? $values['maximum_length'] : '0',
+      '#element_validate' => array('element_validate_integer'),
+      '#description' => t('Maximum field length to render for display. A setting of 0 (default) renders the entire value.'),
+    ),
+    'truncation_suffix' => array(
+      '#type' => 'textfield',
+      '#title' => t('Truncation Suffix'),
+      '#default_value' => isset($values['truncation_suffix']) ? $values['truncation_suffix'] : '...',
+      '#description' => t('If a value is truncated, this will be added to the end of the string.'),
+    ),
+  );
+
   islandora_solr_append_permissions_and_actions($values, $form);
 
   return $form;

--- a/includes/db.inc
+++ b/includes/db.inc
@@ -167,6 +167,26 @@ function islandora_solr_get_link_to_object_fields() {
 }
 
 /**
+ * Return display fields that have a length limit set.
+ *
+ * Returns an associative array with field names as key and truncation
+ * character to use (if any) as value.
+ */
+function islandora_solr_get_trunctate_length_fields() {
+  $records = islandora_solr_get_fields('result_fields', TRUE, FALSE);
+  $truncate_length_fields = array();
+  foreach ($records as $value) {
+    if (isset($value['solr_field_settings']['maximum_length']) && intval($value['solr_field_settings']['maximum_length']) > 0) {
+      $truncate_length_fields[$value['solr_field']] = array(
+        'maximum_length' => $value['solr_field_settings']['maximum_length'],
+        'truncation_suffix' => isset($value['solr_field_settings']['truncation_suffix']) ? $value['solr_field_settings']['truncation_suffix'] : '',
+      );
+    }
+  }
+  return $truncate_length_fields;
+}
+
+/**
  * Return display fields with 'link to search' enabled.
  */
 function islandora_solr_get_link_to_search_fields() {

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -256,6 +256,7 @@ function islandora_solr_prepare_solr_results($solr_results) {
   $highlighting = isset($solr_results['highlighting']) ? $solr_results['highlighting'] : array();
   $fields_all = islandora_solr_get_fields('result_fields', FALSE);
   $link_to_object = islandora_solr_get_link_to_object_fields();
+  $truncate_length = islandora_solr_get_trunctate_length_fields();
   $link_to_search = islandora_solr_get_link_to_search_fields();
   $date_format = islandora_solr_get_date_format_fields();
 
@@ -287,6 +288,16 @@ function islandora_solr_prepare_solr_results($solr_results) {
       // Only apply highlighting when the date isn't formatted.
       elseif (isset($highlighting[$pid][$field])) {
         $value = $highlighting[$pid][$field];
+      }
+
+      // Truncate value lengths before linking, avoids destroying link tags.
+      if (array_key_exists($field, $truncate_length)) {
+        array_walk($value, function(&$val_val, $val_key) use ($field, $truncate_length) {
+          $val_val = strlen($val_val) > intval($truncate_length[$field]['maximum_length']) ?
+            substr($val_val, 0, intval($truncate_length[$field]['maximum_length'])) .
+            $truncate_length[$field]['truncation_suffix'] :
+            $val_val;
+        });
       }
 
       // Add link to search.

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -292,7 +292,7 @@ function islandora_solr_prepare_solr_results($solr_results) {
 
       // Truncate value lengths before linking, avoids destroying link tags.
       if (array_key_exists($field, $truncate_length)) {
-        array_walk($value, function(&$val_val, $val_key) use ($field, $truncate_length) {
+        array_walk($value, function (&$val_val, $val_key) use ($field, $truncate_length) {
           $val_val = strlen($val_val) > intval($truncate_length[$field]['maximum_length']) ?
             substr($val_val, 0, intval($truncate_length[$field]['maximum_length'])) .
             $truncate_length[$field]['truncation_suffix'] :

--- a/islandora_solr_config/includes/table_results.inc
+++ b/islandora_solr_config/includes/table_results.inc
@@ -45,10 +45,6 @@ class IslandoraSolrResultsTable extends IslandoraSolrResults {
       foreach ($fields as $field => $field_label) {
         if (isset($doc[$field]['value'])) {
           $value = $doc[$field]['value'];
-          // @todo This should probably a config option to truncate the value.
-          if (strlen($value) > 150) {
-            $value = substr(filter_xss($value, array()), 0, 150) . ' ...';
-          }
           $row[$field] = $value;
           $empty[$field] = FALSE;
         }


### PR DESCRIPTION
The 7.x implementation of character truncation in table output is hardcoded, and also breaks "Link to Object" functionality in table results (since it truncates the results, stripping tags AFTER the link is created):

https://github.com/Islandora/islandora_solr_search/blob/7.x/includes/utilities.inc#L309-L311
https://github.com/Islandora/islandora_solr_search/blob/7.x/islandora_solr_config/includes/table_results.inc#L48-L51

In an effort to:
- Correct the above issue
- Make character limits/truncation not limited to the 'table' display profile type,

I have:
- Moved the truncation logic to utilities.inc
- Allowed the values to field-configurable by the user through the 'Configure' link in the display field list.

Tested and working in our instance now.
