### PR TITLE
Allow configuration and add class, row display options for table display profile

### DIFF
--- a/islandora_solr_config/includes/admin.inc
+++ b/islandora_solr_config/includes/admin.inc
@@ -137,3 +137,43 @@ function islandora_solr_config_admin_rss_settings_submit($form, &$form_state) {
     variable_del('islandora_solr_config_rss_channel');
   }
 }
+
+/**
+ * Function to return the table profile admin settings form.
+ */
+function islandora_solr_config_admin_table_profile_settings($form, &$form_state) {
+
+  $form['options']['islandora_solr_table_profile_settings'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('General Table Settings'),
+    '#collapsible' => TRUE,
+    '#collapsed' => FALSE,
+    'islandora_solr_table_profile_display_row_no' => array(
+      '#type' => 'checkbox',
+      '#title' => t('Display Row Numbers?'),
+      '#default_value' => variable_get('islandora_solr_table_profile_display_row_no', 1),
+      '#description' => t('Should row numbers be rendered as a column in the results table?'),
+    ),
+    'islandora_solr_table_profile_table_class' => array(
+      '#type' => 'textfield',
+      '#title' => t('Table Class'),
+      '#default_value' => variable_get('islandora_solr_table_profile_table_class', ''),
+      '#description' => t('A class string to set for the table element, if any.'),
+    ),
+  );
+  $form['buttons']['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Save'),
+  );
+
+  return $form;
+}
+
+/**
+ * Function to submit the admin setting form.
+ */
+function islandora_solr_config_admin_table_profile_settings_submit($form, &$form_state) {
+  variable_set('islandora_solr_table_profile_display_row_no', $form_state['values']['islandora_solr_table_profile_display_row_no']);
+  variable_set('islandora_solr_table_profile_table_class', $form_state['values']['islandora_solr_table_profile_table_class']);
+  drupal_set_message(t('The Solr table profile configuration options have been saved.'));
+}

--- a/islandora_solr_config/includes/table_results.inc
+++ b/islandora_solr_config/includes/table_results.inc
@@ -41,7 +41,9 @@ class IslandoraSolrResultsTable extends IslandoraSolrResults {
     foreach ($object_results as $key => $object_result) {
       $row = array();
       $doc = $object_result['solr_doc'];
-      $row['#'] = l(($key + 1), $object_result['object_url'], array('query' => $object_result['object_url_params']));
+      if (variable_get('islandora_solr_table_profile_display_row_no', 1) == 1) {
+        $row['#'] = l(($key + 1), $object_result['object_url'], array('query' => $object_result['object_url_params']));
+      }
       foreach ($fields as $field => $field_label) {
         if (isset($doc[$field]['value'])) {
           $value = $doc[$field]['value'];
@@ -58,7 +60,10 @@ class IslandoraSolrResultsTable extends IslandoraSolrResults {
       }
       $rows[] = $row;
     }
-    $header = array('#' => '#');
+    $header = array();
+    if (variable_get('islandora_solr_table_profile_display_row_no', 1) == 1) {
+      $header['#'] = '#';
+    }
     $header += $fields;
 
     // Filter empty columns.

--- a/islandora_solr_config/islandora_solr_config.install
+++ b/islandora_solr_config/islandora_solr_config.install
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @file
+ * Implementations of installation hooks.
+ */
+
+/**
+ * Implements hook_uninstall().
+ */
+function islandora_solr_config_uninstall() {
+
+  // Removing variables.
+  $variables = array(
+    'islandora_solr_table_profile_display_row_no',
+    'islandora_solr_table_profile_table_class',
+  );
+  foreach ($variables as $variable) {
+    variable_del($variable);
+  }
+}

--- a/islandora_solr_config/islandora_solr_config.module
+++ b/islandora_solr_config/islandora_solr_config.module
@@ -25,6 +25,7 @@ function islandora_solr_config_islandora_solr_primary_display() {
       'class' => "IslandoraSolrResultsTable",
       'function' => "displayResults",
       'description' => t("Display search results as tabular output"),
+      'configuration' => 'admin/islandora/search/islandora_solr/table_profile',
     ),
   );
 }
@@ -69,6 +70,14 @@ function islandora_solr_config_menu() {
     'access arguments' => array('administer islandora solr'),
     'file' => 'includes/admin.inc',
     'type' => MENU_LOCAL_TASK,
+  );
+  $items['admin/islandora/search/islandora_solr/table_profile'] = array(
+    'title' => 'Table Profile Settings',
+    'type' => MENU_LOCAL_TASK,
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('islandora_solr_config_admin_table_profile_settings'),
+    'access arguments' => array('administer islandora solr'),
+    'file' => 'includes/admin.inc',
   );
   return $items;
 }

--- a/islandora_solr_config/theme/islandora-solr-table.tpl.php
+++ b/islandora_solr_config/theme/islandora-solr-table.tpl.php
@@ -15,7 +15,7 @@
 <?php if (empty($rows)): ?>
   <p class="no-results"><?php print t('Sorry, but your search returned no results.'); ?></p>
 <?php else: ?>
-  <table>
+  <table class="<?php print variable_get('islandora_solr_table_profile_table_class', ''); ?>">
     <?php foreach($header as $key => $value):?>
       <th>
         <?php print $value; ?>


### PR DESCRIPTION
No table 'display profile' configuration options are currently implemented in 7.x

I have added a new tab to admin/islandora/search/islandora_solr that defines two basic configuration options:
- Control whether the column ID is shown when the table renders
- Allow assignment of a class to the table for styling

Current 7.x behaviours have been set as defaults. 

![screen shot 2014-10-07 at 3 53 31 pm](https://cloud.githubusercontent.com/assets/244894/4548244/6637d0a0-4e53-11e4-80d4-fab2f7dd9ecf.png)
