### PR TITLE
ISLANDORA-1464

### DIFF
--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -1536,6 +1536,7 @@ function _islandora_solr_handle_solr_field_settings($solr_field_settings = NULL,
           'label' => trim($solr_field_settings['label']),
           'link_rendering' => $solr_field_settings['link_rendering'],
           'snippet' => isset($solr_field_settings['snippet']) ? $solr_field_settings['snippet'] : NULL,
+          'render_object_name' => isset($solr_field_settings['render_object_name']) ? $solr_field_settings['render_object_name'] : FALSE,
           'date_format' => isset($solr_field_settings['date_format']) ? trim($solr_field_settings['date_format']) : '',
           'maximum_length' => isset($solr_field_settings['maximum_length']) ? trim($solr_field_settings['maximum_length']) : '',
           'add_ellipsis' => isset($solr_field_settings['add_ellipsis']) ? $solr_field_settings['add_ellipsis'] : FALSE,
@@ -1741,6 +1742,13 @@ function islandora_solr_admin_settings_result_fields($form, &$form_state, $varia
     '#default_value' => isset($values['snippet']) ? $values['snippet'] : FALSE,
     '#description' => t('If a match is found on this field, the search term will be highlighted.<br /><strong>Note:</strong> Only text that has been both indexed and stored may be highlighted. While highlighting on non-tokenized fields is possible, the best results are achieved using tokenized fields. This checkbox may be grayed out if the Solr field cannot be highlighted.'),
   );
+  $form['options']['render_object_name'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Object Label'),
+    '#default_value' => isset($values['render_object_name']) ? $values['render_object_name'] : FALSE,
+    '#description' => t('Replace PID with object Label.')
+  );
+
   $highlighting_allowed = islandora_solr_check_highlighting_allowed($solr_field);
   if ($highlighting_allowed == FALSE) {
     $form['options']['snippet']['#default_value'] = 0;

--- a/includes/blocks.inc
+++ b/includes/blocks.inc
@@ -752,7 +752,6 @@ function islandora_solr_display() {
       $list_items = array();
 
       foreach ($weight as $key => $value) {
-	
         if ($enabled[$key] !== 0) {
           if (isset($params['display'])) {
             $current_display = $params['display'];
@@ -762,10 +761,6 @@ function islandora_solr_display() {
           }
 
           $display_name = $profiles[$key]['name'];
-		
-	  if ($display_name != "Grid" && $display_name != "List (default)") {
-	    continue;
-	  }
 
           $display_description = isset($profiles[$key]['description']) ? $profiles[$key]['description'] : NULL;
 
@@ -782,23 +777,7 @@ function islandora_solr_display() {
 
           // XXX: We're not using l() because of
           // @link http://drupal.org/node/41595 active classes. @endlink
-        
-          
-        
-          
-          switch ($display_name) {
-          	case "Grid":
-          		$item = '<a' . drupal_attributes($attr) . '> <img src="http://content.library.utoronto.ca/common/rwd/images/grid.png" alt="List view" title="List view" /></a>';
-          		break;
-          	case "List (default)":
-          		$item = '<a' . drupal_attributes($attr) . '> <img src="http://content.library.utoronto.ca/common/rwd/images/list.png" alt="Grid view" title="Grid view"/></a>';		
-          		break;
-          	default:
-          		continue;
-          
-          	
-          }
-          
+          $item = '<a' . drupal_attributes($attr) . '>' . check_plain($display_name) . '</a>';
 
           // Add link to list.
           $list_items[] = $item;

--- a/includes/blocks.inc
+++ b/includes/blocks.inc
@@ -46,7 +46,7 @@ function islandora_solr_islandora_solr_query_blocks() {
       'form' => NULL,
     ),
     'display_switch' => array(
-      'name' => t('Islandora displays'),
+      'name' => t(''),
       'module' => 'islandora_solr',
       'file' => 'includes/blocks.inc',
       'class' => NULL,
@@ -752,6 +752,7 @@ function islandora_solr_display() {
       $list_items = array();
 
       foreach ($weight as $key => $value) {
+	
         if ($enabled[$key] !== 0) {
           if (isset($params['display'])) {
             $current_display = $params['display'];
@@ -761,6 +762,10 @@ function islandora_solr_display() {
           }
 
           $display_name = $profiles[$key]['name'];
+		
+	  if ($display_name != "Grid" && $display_name != "List (default)") {
+	    continue;
+	  }
 
           $display_description = isset($profiles[$key]['description']) ? $profiles[$key]['description'] : NULL;
 
@@ -777,7 +782,23 @@ function islandora_solr_display() {
 
           // XXX: We're not using l() because of
           // @link http://drupal.org/node/41595 active classes. @endlink
-          $item = '<a' . drupal_attributes($attr) . '>' . check_plain($display_name) . '</a>';
+        
+          
+        
+          
+          switch ($display_name) {
+          	case "Grid":
+          		$item = '<a' . drupal_attributes($attr) . '> <img src="http://content.library.utoronto.ca/common/rwd/images/grid.png" alt="List view" title="List view" /></a>';
+          		break;
+          	case "List (default)":
+          		$item = '<a' . drupal_attributes($attr) . '> <img src="http://content.library.utoronto.ca/common/rwd/images/list.png" alt="Grid view" title="Grid view"/></a>';		
+          		break;
+          	default:
+          		continue;
+          
+          	
+          }
+          
 
           // Add link to list.
           $list_items[] = $item;

--- a/includes/db.inc
+++ b/includes/db.inc
@@ -167,6 +167,20 @@ function islandora_solr_get_link_to_object_fields() {
 }
 
 /**
+ * Return display fields with 'render object name'
+ */
+function islandora_solr_get_render_object_name_fields() {
+  $records = islandora_solr_get_fields('result_fields', TRUE, FALSE);
+  $render_object_name_fields = array();
+  foreach ($records as $key => $value) {
+    if (isset($value['solr_field_settings']['render_object_name']) && $value['solr_field_settings']['render_object_name'] == 1) {
+      $render_object_name_fields[] = $value['solr_field'];
+    }
+  }
+  return $render_object_name_fields;
+}
+
+/**
  * Return display fields that have a length limit set.
  *
  * Returns an associative array with field names as key and truncation

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -347,6 +347,8 @@ function islandora_solr_prepare_solr_results($solr_results) {
         $value = array_map($map_to_link, (array) $original_value, (array) $value);
       }
 
+      //get the object label from PID
+      
       if (in_array($field, $render_object_name)) {
         $query_processor = new IslandoraSolrQueryProcessor();
         foreach ($value as $index=>$item) {

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -282,6 +282,7 @@ function islandora_solr_prepare_solr_results($solr_results) {
   $highlighting = isset($solr_results['highlighting']) ? $solr_results['highlighting'] : array();
   $fields_all = islandora_solr_get_fields('result_fields', FALSE);
   $link_to_object = islandora_solr_get_link_to_object_fields();
+  $render_object_name = islandora_solr_get_render_object_name_fields();
   $truncate_length = islandora_solr_get_truncate_length_fields();
   $link_to_search = islandora_solr_get_link_to_search_fields();
   $date_format = islandora_solr_get_date_format_fields();
@@ -346,12 +347,37 @@ function islandora_solr_prepare_solr_results($solr_results) {
         $value = array_map($map_to_link, (array) $original_value, (array) $value);
       }
 
+      if (in_array($field, $render_object_name)) {
+        $query_processor = new IslandoraSolrQueryProcessor();
+        foreach ($value as $index=>$item) {
+          $pid = str_replace("info:fedora/","",$item);
+          if (islandora_is_valid_pid($pid)) {
+            $query_processor->buildQuery("PID:\"$pid\"");
+            $query_processor->solrParams['fl'] = 'PID, ' . variable_get('islandora_solr_object_label_field', 'fgs_label_s');
+            $query_processor->executeQuery();
+            if (!empty($query_processor->islandoraSolrResult) && !empty($query_processor->islandoraSolrResult['response']['objects'])) {
+              $label = (!empty($query_processor->islandoraSolrResult['response']['objects'][0]['object_label']) ?
+              $query_processor->islandoraSolrResult['response']['objects'][0]['object_label'] : NULL);
+            }
+            // Fall back to islandora object if PID is not in solr.
+            // eg: content models.
+            else {
+              if ($object = islandora_object_load($pid)) {
+                $label = $object->label;
+              }
+            }
+            $value[$index] = $label;
+          }
+        }
+      }
+
       // Implode.
       $value = is_array($value) ? implode(", ", $value) : $value;
       // Add link to object.
       if (in_array($field, $link_to_object)) {
         $value = l($value, $object_result['object_url'], $options);
       }
+
       $solr_doc[$field] = $value;
     }
     // Replace Solr doc rows.

--- a/islandora_solr_config/islandora_solr_config.module
+++ b/islandora_solr_config/islandora_solr_config.module
@@ -12,6 +12,7 @@ function islandora_solr_config_islandora_solr_primary_display() {
   return array(
     'grid' => array(
       'name' => t('Grid'),
+      'html' => '<img src="http://content.library.utoronto.ca/common/rwd/images/grid.png" alt="grid view" title="Grid view">',
       'module' => 'islandora_solr_config',
       'file' => 'includes/grid_results.inc',
       'class' => "IslandoraSolrResultsGrid",
@@ -22,7 +23,7 @@ function islandora_solr_config_islandora_solr_primary_display() {
       'name' => t('Table'),
       'module' => 'islandora_solr_config',
       'file' => 'includes/table_results.inc',
-      'class' => "IslandoraSolrResultsTable",
+      'class' => "IslandoraSolrResultsTable grid-item",
       'function' => "displayResults",
       'description' => t("Display search results as tabular output"),
       'configuration' => 'admin/islandora/search/islandora_solr/table_profile',


### PR DESCRIPTION
- add an option for 'Object Label' on 'Configure field' under 'Default display settings' so that when it's turned on it will display actual label of the object instead of raw PID 
- it would be useful for displaying fields such as 'RELS_EXT_isMemberOfCollection_uri_ms'
