### PR TITLE
GUI-configurable simple search fields

### DIFF
--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -568,7 +568,17 @@ function islandora_solr_admin_settings($form, &$form_state) {
     '#type' => 'textarea',
     '#title' => t('Query fields'),
     '#default_value' => variable_get('islandora_solr_query_fields', 'dc.title^5 dc.subject^2 dc.description^2 dc.creator^2 dc.contributor^1 dc.type'),
-    '#description' => t('In case there are no <a href="!url" target="_blank" title="Solr query fields documentation">query fields</a> defined in the request handler, this setting will be used as a fallback.', array('!url' => 'http://wiki.apache.org/solr/DisMaxQParserPlugin#qf_.28Query_Fields.29')),
+    '#description' => t('The <a href="@url" target="_blank" title="Solr query fields documentation">query fields</a> to use for DisMax (simple) searches.', array(
+      '@url' => 'http://wiki.apache.org/solr/DisMaxQParserPlugin#qf_.28Query_Fields.29',
+    )),
+  );
+  $form['islandora_solr_tabs']['query_defaults']['islandora_solr_use_ui_qf'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Prefer defined query fields?'),
+    '#default_value' => variable_get('islandora_solr_use_ui_qf', FALSE),
+    '#description' => t('Use the above "@qf" by default; otherwise, they will only be used as a fallback in the case there are none defined in the selected request handler.', array(
+      '@qf' => t('Query fields'),
+    )),
   );
 
   // Required Solr fields.

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -568,7 +568,7 @@ function islandora_solr_admin_settings($form, &$form_state) {
     '#type' => 'textarea',
     '#title' => t('Query fields'),
     '#default_value' => variable_get('islandora_solr_query_fields', 'dc.title^5 dc.subject^2 dc.description^2 dc.creator^2 dc.contributor^1 dc.type'),
-    '#description' => t('The <a href="@url" target="_blank" title="Solr query fields documentation">query fields</a> to use for DisMax (simple) searches.', array(
+    '#description' => t('<a href="@url" target="_blank" title="Solr query fields documentation">Query fields</a> to use for DisMax (simple) searches.', array(
       '@url' => 'http://wiki.apache.org/solr/DisMaxQParserPlugin#qf_.28Query_Fields.29',
     )),
   );

--- a/includes/query_processor.inc
+++ b/includes/query_processor.inc
@@ -283,10 +283,12 @@ class IslandoraSolrQueryProcessor {
       $this->solrParams['fq'][] = implode(' OR ', $namespace_array);
     }
 
-    // If no qf fields are specified in the requestHandler a default list is
-    // supplied here for dismax searches.
-    if (!islandora_solr_check_dismax() && isset($this->internalSolrParams['type']) && ($this->internalSolrParams['type'] == "dismax" || $this->internalSolrParams['type'] == "edismax")) {
-      $this->solrParams['qf'] = variable_get('islandora_solr_query_fields', 'dc.title^5 dc.subject^2 dc.description^2 dc.creator^2 dc.contributor^1 dc.type');
+    if (isset($this->internalSolrParams['type']) && ($this->internalSolrParams['type'] == "dismax" || $this->internalSolrParams['type'] == "edismax")) {
+      if (variable_get('islandora_solr_use_ui_qf', FALSE) || !islandora_solr_check_dismax()) {
+        // Put our "qf" in if we are configured to, or we have none from the
+        // request handler.
+        $this->solrParams['qf'] = variable_get('islandora_solr_query_fields', 'dc.title^5 dc.subject^2 dc.description^2 dc.creator^2 dc.contributor^1 dc.type');
+      }
     }
 
     // Invoke a hook for third-party modules to alter the parameters.

--- a/islandora_solr.install
+++ b/islandora_solr.install
@@ -73,6 +73,7 @@ function islandora_solr_uninstall() {
     'islandora_solr_datastream_id_field',
     'islandora_solr_allow_preserve_filters',
     'islandora_solr_force_update_index_after_object_purge',
+    'islandora_solr_use_ui_qf',
   );
   foreach ($variables as $variable) {
     variable_del($variable);


### PR DESCRIPTION
**Jira:** https://jira.duraspace.org/browse/ISLANDORA-1530
# What does this Pull Request do?

Allow the GUI-configured `Query fields` (`qf`; the fields for dismax/simple search) to be preferred over those defined in the selected request handler.
# How should this be tested?
1. When not checked (default, matches current functionality):
   1. With `qf` in the request handler, the fields in the `Query fields` textarea should _not_ be used.
   2. Without `qf` in the request handler, the fields in the `Query fields` textarea should be used.
2. When checked:
   1. The fields in the `Query fields` textarea should be used, independent of `qf` existing in the selected request handler.
# Screenshots
## Before Screenshot

![Before Screenshot](http://puu.sh/l727F/3191bffe22.png)
## After Screenshot

![After Screenshot](http://puu.sh/l71NP/5e0437b949.png)
# Additional Notes:
- **Does this change require documentation to be updated?** Unsure: There does not appear to be a mention of "Query fields" in either
  - https://wiki.duraspace.org/display/ISLANDORA/Islandora+Solr+Settings or
  - https://wiki.duraspace.org/pages/viewpage.action?pageId=69833573#Search&DiscoveryinIslandora-7.SetQueryDefaults
  
  and a quick search on the wiki did not turn up any other probabilities. 
- **Could this change impact execution of existing code?** Unlikely; though, possible if one were depending on the absence of the `qf` in the `IslandoraSolrQueryProcessor::$solrParams` when `qf` is defined in the request handler. As this case already depends on external configuration (Solr's request handler) we should consider such code to be in fault.

**Tagging:** @jordandukart (component manager)

---

Adam Vessey
_Developer_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**
