### PR TITLE
ISLANDORA-1553: added option to use default query for empty advanced searches

### DIFF
--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -546,6 +546,12 @@ function islandora_solr_admin_settings($form, &$form_state) {
       Consider using <strong>fgs_createdDate_dt:[* TO NOW]</strong> or <strong>*:*</strong><br />'),
     '#default_value' => variable_get('islandora_solr_base_query', '*:*'),
   );
+  $form['islandora_solr_tabs']['query_defaults']['islandora_solr_base_advanced'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Use default query for empty advanced searches too'),
+    '#description' => t('When selected, an empty advanced search will perform the same as an empty simple search. If not selected, empty advanced searches will search *:*'),
+    '#default_value' => variable_get('islandora_solr_base_advanced', FALSE),
+  );
   $form['islandora_solr_tabs']['query_defaults']['islandora_solr_base_sort'] = array(
     '#type' => 'textfield',
     '#title' => t('Sort field for default query'),

--- a/includes/blocks.inc
+++ b/includes/blocks.inc
@@ -714,7 +714,12 @@ function islandora_solr_advanced_search_form_submit($form, &$form_state) {
 
   // Check if query is empty.
   if (empty($query)) {
-    $query = '*:*';
+    if (variable_get('islandora_solr_base_advanced', FALSE)) {
+      $query = variable_get('islandora_solr_base_query', '*:*');
+    }
+    else {
+      $query = '*:*';
+    }
   }
   // Handle filters.
   $filter = '';

--- a/islandora_solr.install
+++ b/islandora_solr.install
@@ -64,6 +64,7 @@ function islandora_solr_uninstall() {
     'islandora_solr_search_navigation',
     'islandora_solr_namespace_restriction',
     'islandora_solr_base_query',
+    'islandora_solr_base_advanced',
     'islandora_solr_base_sort',
     'islandora_solr_base_filter',
     'islandora_solr_query_fields',


### PR DESCRIPTION
By default nothing should be changed, but there is now a checkbox in the admin form that makes empty advanced searches use the default query.
