### PR TITLE
Check solr type for either date or tdate. (ISLANDORA-1580)

### DIFF
--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -1937,7 +1937,7 @@ function islandora_solr_admin_settings_facet_fields($form, &$form_state, $variab
   );
 
   $luke_result = islandora_solr_get_luke(NULL, $solr_field);
-  if (isset($luke_result['fields'][$solr_field]['type']) && $luke_result['fields'][$solr_field]['type'] == 'date') {
+  if (isset($luke_result['fields'][$solr_field]['type']) && ($luke_result['fields'][$solr_field]['type'] == 'date' || $luke_result['fields'][$solr_field]['type'] == 'tdate')) {
     // Add in defaults, to avoid isset() tests.
     $values += array(
       'range_facet_select' => 0,

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -1775,8 +1775,7 @@ function islandora_solr_admin_settings_result_fields($form, &$form_state, $varia
     $form['options']['snippet']['#disabled'] = TRUE;
   }
 
-  $luke_result = islandora_solr_get_luke(NULL, $solr_field);
-  if (isset($luke_result['fields'][$solr_field]['type']) && $luke_result['fields'][$solr_field]['type'] == 'date') {
+  if (islandora_solr_is_date_field($solr_field)) {
     $form['options']['date_format'] = array(
       '#type' => 'textfield',
       '#title' => t('Date format'),
@@ -1936,8 +1935,7 @@ function islandora_solr_admin_settings_facet_fields($form, &$form_state, $variab
     '#description' => t('A human-readable name.'),
   );
 
-  $luke_result = islandora_solr_get_luke(NULL, $solr_field);
-  if (isset($luke_result['fields'][$solr_field]['type']) && ($luke_result['fields'][$solr_field]['type'] == 'date' || $luke_result['fields'][$solr_field]['type'] == 'tdate')) {
+  if (islandora_solr_is_date_field($solr_field)) {
     // Add in defaults, to avoid isset() tests.
     $values += array(
       'range_facet_select' => 0,

--- a/includes/luke.inc
+++ b/includes/luke.inc
@@ -70,12 +70,15 @@ function islandora_solr_check_http($url) {
  *   include the number of occurrences in the Solr index. Higher occurrences are
  *   listed first. Defaults to 0 because including this can add a siginificant
  *   performance hit.
+ * @param bool $show_schema
+ *   Get the schema information as part of this request. WARNING: Enabling this
+ *   will override a field display and ONLY display the schema information.
  *
  * @return array|bool
  *   Returns Solr Luke data, or boolean FALSE if there was an error (Solr not
  *   available?).
  */
-function islandora_solr_get_luke($solr_url = NULL, $field = NULL, $num_terms = 0) {
+function islandora_solr_get_luke($solr_url = NULL, $field = NULL, $num_terms = 0, $show_schema = FALSE) {
   if (!$solr_url) {
     // Create URL.
     $solr_url = variable_get('islandora_solr_url', 'localhost:8080/solr');
@@ -98,6 +101,9 @@ function islandora_solr_get_luke($solr_url = NULL, $field = NULL, $num_terms = 0
       if ($luke_query['numTerms'] == 0) {
         $luke_query['numTerms'] = 1;
       }
+    }
+    if ($show_schema) {
+      $luke_query['show'] = 'schema';
     }
     // Generate nice URL.
     $luke_url = url($luke_url, array('absolute' => TRUE, 'query' => $luke_query));
@@ -206,4 +212,24 @@ function islandora_solr_check_highlighting_allowed($solr_field = NULL) {
     }
   }
   return FALSE;
+}
+
+/**
+ * Function to get the actual class for a type.
+ *
+ * @param string $solr_type
+ *   Solr type to get the class for.
+ *
+ * @return string
+ *   The classname of the type.
+ */
+function islandora_solr_get_type_class($solr_type) {
+  // Get the schema information
+  $luke_result = islandora_solr_get_luke(NULL, NULL, 0, TRUE);
+  if (isset($luke_result['schema']['types'][$solr_type])) {
+    return $luke_result['schema']['types'][$solr_type]['className'];
+  }
+  else {
+    return FALSE;
+  }
 }

--- a/includes/luke.inc
+++ b/includes/luke.inc
@@ -224,7 +224,7 @@ function islandora_solr_check_highlighting_allowed($solr_field = NULL) {
  *   The classname of the type.
  */
 function islandora_solr_get_type_class($solr_type) {
-  // Get the schema information
+  // Get the schema information.
   $luke_result = islandora_solr_get_luke(NULL, NULL, 0, TRUE);
   if (isset($luke_result['schema']['types'][$solr_type])) {
     return $luke_result['schema']['types'][$solr_type]['className'];

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -450,3 +450,26 @@ function islandora_solr_truncate_field_display($display_values, $max_length, $ad
   }
   return $updated_display_values;
 };
+
+/**
+ * Check the field type against the user-specified list of date field types
+ *
+ * @param string $solr_field
+ *   The Solr field name
+ *
+ * @return boolean
+ *   Whether the field matches the date field types.
+ */
+function islandora_solr_is_date_field($solr_field) {
+  $date_types = array(
+    'org.apache.solr.schema.DateField',
+    'org.apache.solr.schema.TrieDateField',
+  );
+  $luke_result = islandora_solr_get_luke(NULL, $solr_field);
+  $type = (isset($luke_result['fields'][$solr_field]['type']) ? $luke_result['fields'][$solr_field]['type'] : FALSE);
+  if ($type) {
+    $class = islandora_solr_get_type_class($type);
+    return in_array($class, $date_types);
+  }
+  return FALSE;
+}

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -452,12 +452,12 @@ function islandora_solr_truncate_field_display($display_values, $max_length, $ad
 };
 
 /**
- * Check the field type against the user-specified list of date field types
+ * Check the field type against the user-specified list of date field types.
  *
  * @param string $solr_field
  *   The Solr field name
  *
- * @return boolean
+ * @return bool
  *   Whether the field matches the date field types.
  */
 function islandora_solr_is_date_field($solr_field) {


### PR DESCRIPTION
Addresses [ISLANDORA-1580](https://jira.duraspace.org/browse/ISLANDORA-1580)
# What does this Pull Request do?

Checks for both a **date** or **tdate** solr type when adding a new facet.
# How should this be tested?
## Prior to this Pull Request

In the Solr schema.xml field add a type using the solr.TrieDateField

```
<fieldType name="tdate" class="solr.TrieDateField" precisionStep="6" positionIncrementGap="0"/>
```

then add (or change an existing DateField) to use this type

```
<dynamicField name="*_dt" type="tdate"    indexed="true"  stored="true"/>
```

Index or re-index some documents. Then attempt to use this field as a facet in the Islandora Solr Settings page.

You will **not** see the **Range facet** checkbox when you add the new facet field.
## With this Pull Request applied

Performing the above actions, you will see the **Range facet** checkbox the same as a normal DateField.
