### PR TITLE
sortable collections when using solr query backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Set the 'Solr URL' and select a 'Request handler' in Administration » Islandora
 
 Islandora Solr Search offers many more configuration options in Administration » Islandora » Solr Index » Solr settings (admin/islandora/search/islandora_solr/settings).
 
+Islandora Solr Search also implements the Islandora Basic Collection solution pack's query backend to drive the collection display using Solr instead of SPARQL/Fedora. This functionality can be applied on the collection solution pack's configuration page (admin/islandora/solution_pack_config/basic_collection), and that same page provides settings for sorting the Solr collection view globally and per-collection. The query backend relies on the relationship fields in the "Query Defaults" section of the Solr settings; the fields in that section should be confirmed before using Solr to drive the display.
+
 ## Documentation
 
 Further documentation for this module is available at [our wiki](https://wiki.duraspace.org/display/ISLANDORA/Islandora+Solr+Search).

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Set the 'Solr URL' and select a 'Request handler' in Administration » Islandora
 
 Islandora Solr Search offers many more configuration options in Administration » Islandora » Solr Index » Solr settings (admin/islandora/search/islandora_solr/settings).
 
-Islandora Solr Search also implements the Islandora Basic Collection solution pack's query backend to drive the collection display using Solr instead of SPARQL/Fedora. This functionality can be applied on the collection solution pack's configuration page (admin/islandora/solution_pack_config/basic_collection), and that same page provides settings for sorting the Solr collection view globally and per-collection. The query backend relies on the relationship fields in the "Query Defaults" section of the Solr settings; the fields in that section should be confirmed before using Solr to drive the display.
+Islandora Solr Search also implements the Islandora Basic Collection solution pack's query backend to drive the collection display using Solr instead of SPARQL/Fedora. This functionality can be applied on the collection solution pack's configuration page (admin/islandora/solution_pack_config/basic_collection), and that same page provides settings for sorting the Solr collection view globally and per-collection. The query backend relies on the relationship fields in the "Required Solr Fields" section of the Solr settings; the fields in that section should be confirmed before using Solr to drive the display.
 
 ## Documentation
 

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -562,6 +562,13 @@ function islandora_solr_admin_settings($form, &$form_state) {
       array('!url' => 'http://wiki.apache.org/solr/CommonQueryParameters#sort')),
     '#default_value' => variable_get('islandora_solr_base_sort', ''),
   );
+  $form['islandora_solr_tabs']['query_defaults']['islandora_solr_collection_sort'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Sort field for collection query'),
+    '#size' => 30,
+    '#description' => t('Indicates an alternate default method for sorting collection items when using the Solr collection display backend, if the same method for sorting search results is not desireable. Otherwise, the default query sort will be used for collection query sorting.'),
+    '#default_value' => variable_get('islandora_solr_collection_sort', ''),
+  );
   $form['islandora_solr_tabs']['query_defaults']['islandora_solr_base_filter'] = array(
     '#type' => 'textarea',
     '#title' => t('Solr base filter'),

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -561,20 +561,7 @@ function islandora_solr_admin_settings($form, &$form_state) {
     For more information, check the <a href="!url">Solr documentation</a>.',
       array('!url' => 'http://wiki.apache.org/solr/CommonQueryParameters#sort')),
     '#default_value' => variable_get('islandora_solr_base_sort', ''),
-  );
-  $form['islandora_solr_tabs']['query_defaults']['islandora_solr_collection_sort'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Sort field for collection query'),
-    '#size' => 30,
-    '#description' => t('Indicates an alternate default method for sorting collection members when using the Solr collection display backend. If unset, the default query sort above will be used.'),
-    '#default_value' => variable_get('islandora_solr_collection_sort', ''),
-  );
-  $form['islandora_solr_tabs']['query_defaults']['islandora_solr_individual_collection_sorting'] = array(
-    '#type' => 'checkbox',
-    '#title' => t('Allow individual sort strings per-collection'),
-    '#description' => t('Allows per-collection sort strings to be configured. These sort strings can be set on the collection configuration page for individual collection objects.'),
-    '#default_value' => variable_get('islandora_solr_individual_collection_sorting', FALSE),
-  );
+  ); 
   $form['islandora_solr_tabs']['query_defaults']['islandora_solr_base_filter'] = array(
     '#type' => 'textarea',
     '#title' => t('Solr base filter'),

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -561,7 +561,7 @@ function islandora_solr_admin_settings($form, &$form_state) {
     For more information, check the <a href="!url">Solr documentation</a>.',
       array('!url' => 'http://wiki.apache.org/solr/CommonQueryParameters#sort')),
     '#default_value' => variable_get('islandora_solr_base_sort', ''),
-  ); 
+  );
   $form['islandora_solr_tabs']['query_defaults']['islandora_solr_base_filter'] = array(
     '#type' => 'textarea',
     '#title' => t('Solr base filter'),

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -569,6 +569,12 @@ function islandora_solr_admin_settings($form, &$form_state) {
     '#description' => t('Indicates an alternate default method for sorting collection items when using the Solr collection display backend, if the same method for sorting search results is not desireable. Otherwise, the default query sort will be used for collection query sorting.'),
     '#default_value' => variable_get('islandora_solr_collection_sort', ''),
   );
+  $form['islandora_solr_tabs']['query_defaults']['islandora_solr_individual_collection_sorting'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Allow individual sort strings per-collection'),
+    '#description' => t('Enables per-collection sort string configurations to be stored in and requested from the database. These sort strings can be set on the collection configuration page for individual collection objects.'),
+    '#default_value' => variable_get('islandora_solr_individual_collection_sorting', FALSE),
+  );
   $form['islandora_solr_tabs']['query_defaults']['islandora_solr_base_filter'] = array(
     '#type' => 'textarea',
     '#title' => t('Solr base filter'),

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -566,13 +566,13 @@ function islandora_solr_admin_settings($form, &$form_state) {
     '#type' => 'textfield',
     '#title' => t('Sort field for collection query'),
     '#size' => 30,
-    '#description' => t('Indicates an alternate default method for sorting collection items when using the Solr collection display backend, if the same method for sorting search results is not desireable. Otherwise, the default query sort will be used for collection query sorting.'),
+    '#description' => t('Indicates an alternate default method for sorting collection members when using the Solr collection display backend. If unset, the default query sort above will be used.'),
     '#default_value' => variable_get('islandora_solr_collection_sort', ''),
   );
   $form['islandora_solr_tabs']['query_defaults']['islandora_solr_individual_collection_sorting'] = array(
     '#type' => 'checkbox',
     '#title' => t('Allow individual sort strings per-collection'),
-    '#description' => t('Enables per-collection sort string configurations to be stored in and requested from the database. These sort strings can be set on the collection configuration page for individual collection objects.'),
+    '#description' => t('Allows per-collection sort strings to be configured. These sort strings can be set on the collection configuration page for individual collection objects.'),
     '#default_value' => variable_get('islandora_solr_individual_collection_sorting', FALSE),
   );
   $form['islandora_solr_tabs']['query_defaults']['islandora_solr_base_filter'] = array(

--- a/includes/collection_sort.form.inc
+++ b/includes/collection_sort.form.inc
@@ -22,20 +22,18 @@ function islandora_solr_manage_collection_sort_form(array $form, array &$form_st
   module_load_include('inc', 'islandora_solr', 'includes/db');
   $current_default = islandora_solr_get_collection_sort_string($object->id);
   $form_state['collection'] = $object->id;
-  $collection_sort = variable_get('islandora_solr_collection_sort', 'Not set');
-  $base_sort = variable_get('islandora_solr_base_sort', 'Not set');
+  $collection_sort = variable_get('islandora_solr_collection_sort', '');
+  $base_sort = variable_get('islandora_solr_base_sort', '');
   return array(
     '#action' => request_uri() . '#manage-collection-solr-sort',
     'collection_sort_string' => array(
       '#type' => 'textfield',
       '#title' => t('Solr Collection Sort String'),
-      '#description' => t('A string representing a sort parameter to add if using the Solr collection query backend. Can be set to empty to fall back to the global sort setting for collections, or the global base sort setting if there is none. Note that adding multivalued or otherwise unsortable fields here will break the collection view.</br>
-      Global Collection Sort: %collection_sort</br>
-      Global Base Sort: %base_sort</br>', array(
-        '%collection_sort' => empty($collection_sort) ? "Empty" : $collection_sort,
-        '%base_sort' => empty($base_sort) ? "Empty" : $base_sort,
+      '#description' => t('One or more non-multivalued Solr fields to sort by when using the Solr collection query backend. If set to empty, this collection will to fall back to the global sort settings in the order listed below.</br>Global Collection Sort: %collection_sort</br>Global Base Sort: %base_sort</br>', array(
+        '%collection_sort' => empty($collection_sort) ? t("Not set") : $collection_sort,
+        '%base_sort' => empty($base_sort) ? t("Not set") : $base_sort,
       )),
-      '#default_value' => (string) $current_default,
+      '#default_value' => $current_default,
       // These strings can get big haha ...
       '#size' => 100,
     ),

--- a/includes/collection_sort.form.inc
+++ b/includes/collection_sort.form.inc
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @file
+ * Form for collection sort settings.
+ */
+
+/**
+ * Form to set collection sort string.
+ *
+ * @param array $form
+ *   The Drupal form.
+ * @param array $form_state
+ *   The Drupal form state.
+ * @param AbstractObject $object
+ *   The collection object.
+ *
+ * @return array
+ *   The collection sort management form.
+ */
+function islandora_solr_manage_collection_sort_form(array $form, array &$form_state, AbstractObject $object) {
+  module_load_include('inc', 'islandora_solr', 'includes/db');
+  $current_default = islandora_solr_get_collection_sort_string($object->id);
+  $form_state['collection'] = $object->id;
+  $collection_sort = variable_get('islandora_solr_collection_sort', 'Not set');
+  $base_sort = variable_get('islandora_solr_base_sort', 'Not set');
+  return array(
+    '#action' => request_uri() . '#manage-collection-solr-sort',
+    'collection_sort_string' => array(
+      '#type' => 'textfield',
+      '#title' => t('Solr Collection Sort String'),
+      '#description' => t('A string representing a sort parameter to add if using the Solr collection query backend. Can be set to empty to fall back to the global sort setting for collections, or the global base sort setting if there is none. Note that adding multivalued or otherwise unsortable fields here will break the collection view.</br>
+      Global Collection Sort: %collection_sort</br>
+      Global Base Sort: %base_sort</br>', array(
+        '%collection_sort' => empty($collection_sort) ? "Empty" : $collection_sort,
+        '%base_sort' => empty($base_sort) ? "Empty" : $base_sort,
+      )),
+      '#default_value' => (string) $current_default,
+      // These strings can get big haha ...
+      '#size' => 100,
+    ),
+    'submit' => array(
+      '#type' => 'submit',
+      '#value' => t('Apply'),
+    ),
+  );
+}
+
+/**
+ * Submit handler for the collection sort management form.
+ *
+ * @param array $form
+ *   The Drupal form.
+ * @param array $form_state
+ *   The Drupal form state.
+ */
+function islandora_solr_manage_collection_sort_form_submit(array $form, array &$form_state) {
+  islandora_solr_set_collection_sort_string($form_state['collection'], $form_state['values']['collection_sort_string']);
+}

--- a/includes/db.inc
+++ b/includes/db.inc
@@ -309,26 +309,16 @@ function islandora_solr_set_collection_sort_string($pid, $string) {
   );
   // If the current sort string is NULL, then the PID wasn't found in the
   // database.
-  if (is_null($current)) {
+  if ($current !== $string) {
     if (!empty($string)) {
-      db_insert('islandora_solr_collection_sort_strings')
+      db_merge('islandora_solr_collection_sort_strings')
+        ->key(array('collection_pid' => $pid))
         ->fields(array(
           'collection_pid' => $pid,
           'sort_string' => $string,
         ))
         ->execute();
-      drupal_set_message(t('Sort string "@sort_string" added for @collection.', $message_args));
-    }
-  }
-  elseif ($current !== $string) {
-    if (!empty($string)) {
-      db_update('islandora_solr_collection_sort_strings')
-        ->fields(array(
-          'sort_string' => $string,
-        ))
-        ->condition('collection_pid', $pid, '=')
-        ->execute();
-      drupal_set_message(t('Sort string for @collection updated to "@sort_string".', $message_args));
+      drupal_set_message(t('Sort string for @collection set to "@sort_string".', $message_args));
     }
     // In the case where the new string is empty, drop this entry so we can fall
     // back to global defaults.

--- a/includes/db.inc
+++ b/includes/db.inc
@@ -265,18 +265,20 @@ function islandora_solr_translate_field_labels(array &$records) {
  *   The sort string for this collection, or NULL if none exist.
  */
 function islandora_solr_get_collection_sort_string($pid, $use_fallbacks = FALSE) {
-  // Try to get the collection sort entry for this collection.
-  $query = db_select('islandora_solr_collection_sort_strings', 'ss')
-    ->fields('ss', array('sort_string'))
-    ->condition('collection_pid', $pid, '=')
-    ->execute()
-    ->fetchField();
+  // Try to get the collection sort entry for this collection, if enabled.
+  if (variable_get('islandora_solr_individual_collection_sorting', FALSE)) {
+    $query = db_select('islandora_solr_collection_sort_strings', 'ss')
+      ->fields('ss', array('sort_string'))
+      ->condition('collection_pid', $pid, '=')
+      ->execute()
+      ->fetchField();
 
-  if (is_string($query)) {
-    return $query;
+    if (is_string($query)) {
+      return $query;
+    }
   }
 
-  // Use fallbacks if that failed and fallbacks are wanted.
+  // Fall back, if wanted.
   if ($use_fallbacks) {
     $sort = variable_get('islandora_solr_collection_sort', '');
     if (!empty($sort)) {

--- a/includes/db.inc
+++ b/includes/db.inc
@@ -252,3 +252,92 @@ function islandora_solr_translate_field_labels(array &$records) {
     }
   }
 }
+
+/**
+ * Get the sort string for a collection.
+ *
+ * @param string $pid
+ *   The PID of the collection.
+ * @param bool $use_fallbacks
+ *   Whether or not to attempt to use collection sort fallbacks.
+ *
+ * @return string|null
+ *   The sort string for this collection, or NULL if none exist.
+ */
+function islandora_solr_get_collection_sort_string($pid, $use_fallbacks = FALSE) {
+  // Try to get the collection sort entry for this collection.
+  $query = db_select('islandora_solr_collection_sort_strings', 'ss')
+    ->fields('ss', array('sort_string'))
+    ->condition('collection_pid', $pid, '=')
+    ->execute()
+    ->fetchField();
+
+  if (is_string($query)) {
+    return $query;
+  }
+
+  // Use fallbacks if that failed and fallbacks are wanted.
+  if ($use_fallbacks) {
+    $sort = variable_get('islandora_solr_collection_sort', '');
+    if (!empty($sort)) {
+      return $sort;
+    }
+    $sort = variable_get('islandora_solr_base_sort', '');
+    if (!empty($sort)) {
+      return $sort;
+    }
+  }
+  // If all else fails, just don't set it at all.
+  return NULL;
+}
+
+/**
+ * Sets or updates the Solr sort string for a collection.
+ *
+ * @param string $pid
+ *   The collection PID.
+ * @param string $string
+ *   The string to set it to.
+ */
+function islandora_solr_set_collection_sort_string($pid, $string) {
+  $current = islandora_solr_get_collection_sort_string($pid);
+  $message_args = array(
+    '@collection' => $pid,
+    '@sort_string' => $string,
+  );
+  // If the current sort string is NULL, then the PID wasn't found in the
+  // database.
+  if (is_null($current)) {
+    if (!empty($string)) {
+      db_insert('islandora_solr_collection_sort_strings')
+        ->fields(array(
+          'collection_pid' => $pid,
+          'sort_string' => $string,
+        ))
+        ->execute();
+      drupal_set_message(t('Sort string "@sort_string" added for @collection.', $message_args));
+    }
+  }
+  elseif ($current !== $string) {
+    if (!empty($string)) {
+      db_update('islandora_solr_collection_sort_strings')
+        ->fields(array(
+          'sort_string' => $string,
+        ))
+        ->condition('collection_pid', $pid, '=')
+        ->execute();
+      drupal_set_message(t('Sort string for @collection updated to "@sort_string".', $message_args));
+    }
+    // In the case where the new string is empty, drop this entry so we can fall
+    // back to global defaults.
+    else {
+      db_delete('islandora_solr_collection_sort_strings')
+        ->condition('collection_pid', $pid)
+        ->execute();
+      drupal_set_message(t('Removed sort string for collection @collection.', $message_args));
+    }
+  }
+  else {
+    drupal_set_message(t('No change was made to the sort string for collection @collection.', $message_args));
+  }
+}

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -367,6 +367,7 @@ function islandora_solr_prepare_solr_results($solr_results) {
  * Implements callback_islandora_basic_collection_query_backends().
  */
 function islandora_solr_islandora_basic_collection_backend_callable($collection_object, $page, $limit) {
+  module_load_include('inc', 'islandora_solr', 'includes/db');
   // XXX: We populate the global query class, to allow the sort and facet
   // blocks and the like to function.
   global $_islandora_solr_queryclass;
@@ -380,6 +381,7 @@ function islandora_solr_islandora_basic_collection_backend_callable($collection_
   )), drupal_get_query_parameters());
   $qp->solrStart = $page * $limit;
   $qp->solrLimit = $limit;
+  $qp->solrParams['sort'] = islandora_solr_get_collection_sort_string($collection_object->id, TRUE);
   $qp->executeQuery();
 
   $map_to_pids = function ($result) {

--- a/islandora_solr.install
+++ b/islandora_solr.install
@@ -65,6 +65,7 @@ function islandora_solr_uninstall() {
     'islandora_solr_namespace_restriction',
     'islandora_solr_base_query',
     'islandora_solr_base_sort',
+    'islandora_solr_collection_sort',
     'islandora_solr_base_filter',
     'islandora_solr_query_fields',
     'islandora_solr_debug_mode',
@@ -117,6 +118,25 @@ function islandora_solr_schema() {
       ),
     ),
     'primary key' => array('solr_field', 'field_type'),
+  );
+  $schema['islandora_solr_collection_sort_strings'] = array(
+    'description' => 'Table that stores sort strings for collection objects.',
+    'fields' => array(
+      'collection_pid' => array(
+        'type' => 'varchar',
+        'length' => 255,
+        'not_null' => TRUE,
+        'description' => 'The collection PID',
+      ),
+      'sort_string' => array(
+        'type' => 'varchar',
+        'length' => 255,
+        'not_null' => TRUE,
+        'default' => '',
+        'description' => 'Sort string for the collection',
+      ),
+    ),
+    'primary key' => array('collection_pid'),
   );
   return $schema;
 }
@@ -226,4 +246,12 @@ function islandora_solr_update_7000() {
   foreach ($old_variables_other as $old_variable_other) {
     variable_del($old_variable_other);
   }
+}
+
+/**
+ * Add the table for collection sort strings.
+ */
+function islandora_solr_update_7001() {
+  $schema = islandora_solr_schema();
+  db_create_table('islandora_solr_collection_sort_strings', $schema['islandora_solr_collection_sort_strings']);
 }

--- a/islandora_solr.install
+++ b/islandora_solr.install
@@ -130,8 +130,9 @@ function islandora_solr_schema() {
         'description' => 'The collection PID',
       ),
       'sort_string' => array(
-        'type' => 'varchar',
-        'length' => 255,
+        'type' => 'text',
+        'size' => 'medium',
+        'binary' => TRUE,
         'not_null' => TRUE,
         'default' => '',
         'description' => 'Sort string for the collection',

--- a/islandora_solr.install
+++ b/islandora_solr.install
@@ -132,7 +132,6 @@ function islandora_solr_schema() {
       'sort_string' => array(
         'type' => 'text',
         'size' => 'medium',
-        'binary' => TRUE,
         'not_null' => TRUE,
         'description' => 'Sort string for the collection',
       ),

--- a/islandora_solr.install
+++ b/islandora_solr.install
@@ -66,6 +66,7 @@ function islandora_solr_uninstall() {
     'islandora_solr_base_query',
     'islandora_solr_base_sort',
     'islandora_solr_collection_sort',
+    'islandora_solr_individual_collection_sorting',
     'islandora_solr_base_filter',
     'islandora_solr_query_fields',
     'islandora_solr_debug_mode',

--- a/islandora_solr.install
+++ b/islandora_solr.install
@@ -134,7 +134,6 @@ function islandora_solr_schema() {
         'size' => 'medium',
         'binary' => TRUE,
         'not_null' => TRUE,
-        'default' => '',
         'description' => 'Sort string for the collection',
       ),
     ),

--- a/islandora_solr.module
+++ b/islandora_solr.module
@@ -507,3 +507,29 @@ function islandora_solr_islandora_basic_collection_build_manage_object($form_sta
     return $form_state;
   }
 }
+
+/**
+ * Implements hook_form_islandora_basic_collection_admin_alter().
+ */
+function islandora_solr_form_islandora_basic_collection_admin_alter(&$form, &$form_state, $form_id) {
+  $states = array(
+    'visible' => array(
+      ':input[name="islandora_basic_collection_display_backend"]' => array('value' => 'islandora_solr_query_backend'),
+    ),
+  );
+  $form['display_generation_fieldset']['islandora_collection_display']['islandora_solr_collection_sort'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Sort field for collection query'),
+    '#size' => 100,
+    '#description' => t('Indicates an alternate default method for sorting collection members when using the Solr query backend. If unset, the Solr default query sort will be used.'),
+    '#default_value' => variable_get('islandora_solr_collection_sort', ''),
+    '#states' => $states,
+  );
+  $form['display_generation_fieldset']['islandora_collection_display']['islandora_solr_individual_collection_sorting'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Allow individual sort strings per-collection'),
+    '#description' => t('Allows per-collection sort strings to be configured. These sort strings can be set on the collection configuration page for individual collection objects.'),
+    '#default_value' => variable_get('islandora_solr_individual_collection_sorting', FALSE),
+    '#states' => $states,
+  );
+}

--- a/islandora_solr.module
+++ b/islandora_solr.module
@@ -489,3 +489,19 @@ function islandora_solr_islandora_object_purged($pid) {
     $response = drupal_http_request(variable_get('islandora_solr_url', 'localhost:8080/solr') . '/update', $options);
   }
 }
+
+/**
+ * Implements hook_islandora_basic_collection_build_manage_object().
+ */
+function islandora_solr_islandora_basic_collection_build_manage_object($form_state, $object) {
+  module_load_include('inc', 'islandora_solr', 'includes/collection_sort.form');
+  $form_state['manage_collection_object']['manage_collection_solr_sort'] = array(
+    '#id' => 'manage-collection-solr-sort',
+    '#group' => 'manage_collection_solr_sort',
+    '#access' => TRUE,
+    '#type' => 'fieldset',
+    '#title' => t('Set Solr Sort String'),
+    'form' => drupal_get_form('islandora_solr_manage_collection_sort_form', $object),
+  );
+  return $form_state;
+}

--- a/islandora_solr.module
+++ b/islandora_solr.module
@@ -494,14 +494,16 @@ function islandora_solr_islandora_object_purged($pid) {
  * Implements hook_islandora_basic_collection_build_manage_object().
  */
 function islandora_solr_islandora_basic_collection_build_manage_object($form_state, $object) {
-  module_load_include('inc', 'islandora_solr', 'includes/collection_sort.form');
-  $form_state['manage_collection_object']['manage_collection_solr_sort'] = array(
-    '#id' => 'manage-collection-solr-sort',
-    '#group' => 'manage_collection_solr_sort',
-    '#access' => TRUE,
-    '#type' => 'fieldset',
-    '#title' => t('Set Solr Sort String'),
-    'form' => drupal_get_form('islandora_solr_manage_collection_sort_form', $object),
-  );
-  return $form_state;
+  if (variable_get('islandora_solr_individual_collection_sorting', FALSE)) {
+    module_load_include('inc', 'islandora_solr', 'includes/collection_sort.form');
+    $form_state['manage_collection_object']['manage_collection_solr_sort'] = array(
+      '#id' => 'manage-collection-solr-sort',
+      '#group' => 'manage_collection_solr_sort',
+      '#access' => TRUE,
+      '#type' => 'fieldset',
+      '#title' => t('Set Solr Sort String'),
+      'form' => drupal_get_form('islandora_solr_manage_collection_sort_form', $object),
+    );
+    return $form_state;
+  }
 }


### PR DESCRIPTION
**Jira:** https://jira.duraspace.org/browse/ISLANDORA-1588
# What does this Pull Request do?

This adds Solr sorting natively into the collection view when using the Solr query backend, both with a global sort and with sorting per-collection.

The reasons why this would be nice to have are detailed in the Jira ticket above.
# How should this be tested?

The `islandora_solr_search` module should be updated, and the Drupal database update hooks should be run to add the new sort string table to the database.

A new variable has been added, `islandora_solr_collection_sort`, that acts as a global sort setting for collections.

When using the Solr query backend for collection display, collections should:
- default to sorting by the Solr base sort setting
- sort instead by the Solr collection sort if that exists

A second variable has been added, `islandora_solr_individual_collection_sorting`, that toggles the ability to store individual collection sort strings in the database. An individual collection sort string, if found, takes precedence over the above two sort strings.
# Background context:

Most of this is addressed in the Jira ticket above, but the gist is this: the sort method for searching and the sort method for collection display most likely shouldn't be the same. In fact, the sort field used per-collection may not even be the same, because different collections may use different types of metadata. This will allow us to differentiate between these two things.
# Additional Notes:
- **Does this change require documentation to be updated?** Yes, new configuration options have been added, plus an update hook is required to be run.
- **Does this change add any new dependencies?** No
- **Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?** No; this should work fine without repository modifications. In addition, by default, behaviour for the Solr collection display backend should remain the same unless sort strings are modified.
- **Could this change impact execution of existing code?** This shouldn't touch existing code.

**Tagging:** @jordandukart as the maintainer of this thingy

---

Something or other Dan
_Developer_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**
