### PR TITLE
ISLANDORA-1623: Fixed linking when truncating fields.

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -332,29 +332,20 @@ function islandora_solr_prepare_solr_results($solr_results) {
         array_walk($value, $truncate_func);
       }
 
-      // Add link to search.
-      if (in_array($field, $link_to_search)) {
-        $map_to_link = function ($original_value, $formatted_value) use ($field) {
-          $solr_query = format_string('!field:"!value"', array(
-            '!field' => $field,
-            '!value' => islandora_solr_lesser_escape($original_value),
-          ));
-          return l($formatted_value, "islandora/search/$solr_query", array(
-            'html' => TRUE,
-          ));
-        };
-        $value = array_map($map_to_link, (array) $original_value, (array) $value);
-      }
       // Truncate output based on the field rather than by value.
       if (array_key_exists($field, $truncate_length) && $truncate_length[$field]['maximum_length'] > 0 && isset($truncate_length[$field]['truncation_type']) && $truncate_length[$field]['truncation_type'] == 'whole_field_option') {
-        $value = islandora_solr_truncate_field_display($value, $truncate_length[$field]['maximum_length'], $truncate_length[$field]['add_ellipsis'], $truncate_length[$field]['wordsafe'], $truncate_length[$field]['wordsafe_length'], "<br />");
+        $link = in_array($field, $link_to_object);
+        $link_options = array(
+          'link_to_object' => in_array($field, $link_to_object),
+          'link_to_search' => in_array($field, $link_to_search),
+          'field' => $field,
+          'url' => $object_result['object_url'],
+          'options' => $options
+        );
+        $value = islandora_solr_truncate_field_display($value, $truncate_length[$field]['maximum_length'], $truncate_length[$field]['add_ellipsis'], $truncate_length[$field]['wordsafe'], $truncate_length[$field]['wordsafe_length'], "<br />", $link_options);
       }
       // Implode.
       $value = is_array($value) ? implode(", ", $value) : $value;
-      // Add link to object.
-      if (in_array($field, $link_to_object)) {
-        $value = l($value, $object_result['object_url'], $options);
-      }
       $solr_doc[$field] = $value;
     }
     // Replace Solr doc rows.
@@ -394,8 +385,7 @@ function islandora_solr_islandora_basic_collection_backend_callable($collection_
 };
 
 /**
- * Truncate the field display based on entire field result(s).
- *
+ * Truncate and optionally link the field display based on entire field result(s).
  *
  * @param array $display_values
  *   An array of the values that are to be processed for truncation.
@@ -409,11 +399,20 @@ function islandora_solr_islandora_basic_collection_backend_callable($collection_
  *   Min wordsafe length.
  * @param string $separator
  *   A separator to use for display output.
+ * @param array $link_options
+ *   An array of link options including:
+ *     array(
+ *       'link_to_object' => bool,
+ *       'link_to_search' => bool,
+ *       'field' => {SOLR Result Field},
+ *       'url' => {SOLR object results object_url},
+ *       'options' => link to object l() options param
+ *     );
  *
  * @return string
  *   The updated display values.
  */
-function islandora_solr_truncate_field_display($display_values, $max_length, $add_ellipsis, $word_safe, $wordsafe_length, $separator) {
+function islandora_solr_truncate_field_display($display_values, $max_length, $add_ellipsis, $word_safe, $wordsafe_length, $separator, $link_options) {
   $updated_display_values = $display_values;
   if (count($updated_display_values) > 0) {
     $mod_path = drupal_get_path('module', 'islandora_solr');
@@ -438,15 +437,28 @@ function islandora_solr_truncate_field_display($display_values, $max_length, $ad
         break;
       }
     }
+
+    $original_value = implode($separator, $updated_display_values);
+    if (isset($link_options['link_to_object']) && $link_options['link_to_object'] == TRUE) {
+      $original_value = l($original_value, $link_options['url'], $link_options['options']);
+    } else if (isset($link_options['link_to_search']) && $link_options['link_to_search'] == TRUE) {
+      $solr_query = format_string('!field:"!value"', array(
+        '!field' => $link_options['field'],
+        '!value' => islandora_solr_lesser_escape($original_value),
+        ));
+      $original_value = l($original_value, "islandora/search/$solr_query", array(
+        'html' => TRUE,
+      ));
+    }
     $updated_display_values
-      = '<span class="toggle-wrapper">' .
+      = "<span class='toggle-wrapper'>" .
       t("<span>!value !separator<a href='#' class='toggler'>Show more</a></span>", array(
         '!separator' => $separator,
         '!value' => implode($separator, $truncated_list),
       )) .
       t("<span>!original_value !separator<a href='#' class='toggler'>Show less</a></span>", array(
         '!separator' => $separator,
-        '!original_value' => implode($separator, $display_values),
+        '!original_value' => $original_value,
       )) .
       '</span>';
   }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -340,7 +340,7 @@ function islandora_solr_prepare_solr_results($solr_results) {
           'link_to_search' => in_array($field, $link_to_search),
           'field' => $field,
           'url' => $object_result['object_url'],
-          'options' => $options
+          'options' => $options,
         );
         $value = islandora_solr_truncate_field_display($value, $truncate_length[$field]['maximum_length'], $truncate_length[$field]['add_ellipsis'], $truncate_length[$field]['wordsafe'], $truncate_length[$field]['wordsafe_length'], "<br />", $link_options);
       }
@@ -357,7 +357,8 @@ function islandora_solr_prepare_solr_results($solr_results) {
             ));
           };
           $value = array_map($map_to_link, (array) $original_value, (array) $value);
-        } else if (in_array($field, $link_to_object)) {
+        }
+        elseif (in_array($field, $link_to_object)) {
           $value = l(implode($value), $object_result['object_url'], $options);
         }
       }
@@ -403,7 +404,7 @@ function islandora_solr_islandora_basic_collection_backend_callable($collection_
 };
 
 /**
- * Truncate and optionally link the field display based on entire field result(s).
+ * Truncate and link the field display based on entire field result(s).
  *
  * @param array $display_values
  *   An array of the values that are to be processed for truncation.
@@ -419,13 +420,11 @@ function islandora_solr_islandora_basic_collection_backend_callable($collection_
  *   A separator to use for display output.
  * @param array $link_options
  *   An array of link options including:
- *     array(
- *       'link_to_object' => bool,
- *       'link_to_search' => bool,
- *       'field' => {SOLR Result Field},
- *       'url' => {SOLR object results object_url},
- *       'options' => link to object l() options param
- *     );
+ *   - 'link_to_object' : (bool) Include link to object.
+ *   - 'link_to_search' : (bool) Include link to search results.
+ *   - 'field' : (SOLR Result Field) Result field.
+ *   - 'url' : (SOLR object results object_url) objects result url.
+ *   - 'options' : link to object l() options param.
  *
  * @return string
  *   The updated display values.
@@ -459,14 +458,19 @@ function islandora_solr_truncate_field_display($display_values, $max_length, $ad
     $original_value = implode($separator, $updated_display_values);
     if (isset($link_options['link_to_object']) && $link_options['link_to_object'] == TRUE) {
       $original_value = l($original_value, $link_options['url'], $link_options['options']);
-    } else if (isset($link_options['link_to_search']) && $link_options['link_to_search'] == TRUE) {
+    }
+    elseif (isset($link_options['link_to_search']) && $link_options['link_to_search'] == TRUE) {
       $solr_query = format_string('!field:"!value"', array(
         '!field' => $link_options['field'],
         '!value' => islandora_solr_lesser_escape($original_value),
         ));
-      $original_value = l($original_value, "islandora/search/$solr_query", array(
-        'html' => TRUE,
-      ));
+      $original_value = l(
+        $original_value,
+        "islandora/search/$solr_query",
+        array(
+          'html' => TRUE,
+        )
+      );
     }
     $updated_display_values
       = "<span class='toggle-wrapper'>" .

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -334,7 +334,7 @@ function islandora_solr_prepare_solr_results($solr_results) {
 
       // Truncate output based on the field rather than by value.
       if (array_key_exists($field, $truncate_length) && $truncate_length[$field]['maximum_length'] > 0 && isset($truncate_length[$field]['truncation_type']) && $truncate_length[$field]['truncation_type'] == 'whole_field_option') {
-        $link = in_array($field, $link_to_object);
+        // Handle linking and truncating together.
         $link_options = array(
           'link_to_object' => in_array($field, $link_to_object),
           'link_to_search' => in_array($field, $link_to_search),
@@ -344,6 +344,24 @@ function islandora_solr_prepare_solr_results($solr_results) {
         );
         $value = islandora_solr_truncate_field_display($value, $truncate_length[$field]['maximum_length'], $truncate_length[$field]['add_ellipsis'], $truncate_length[$field]['wordsafe'], $truncate_length[$field]['wordsafe_length'], "<br />", $link_options);
       }
+      else {
+        // Add link to search.
+        if (in_array($field, $link_to_search)) {
+          $map_to_link = function ($original_value, $formatted_value) use ($field) {
+            $solr_query = format_string('!field:"!value"', array(
+              '!field' => $field,
+              '!value' => islandora_solr_lesser_escape($original_value),
+            ));
+            return l($formatted_value, "islandora/search/$solr_query", array(
+              'html' => TRUE,
+            ));
+          };
+          $value = array_map($map_to_link, (array) $original_value, (array) $value);
+        } else if (in_array($field, $link_to_object)) {
+          $value = l(implode($value), $object_result['object_url'], $options);
+        }
+      }
+
       // Implode.
       $value = is_array($value) ? implode(", ", $value) : $value;
       $solr_doc[$field] = $value;

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -418,8 +418,8 @@ function islandora_solr_islandora_basic_collection_backend_callable($collection_
  *   Min wordsafe length.
  * @param string $separator
  *   A separator to use for display output.
- * @param array $link_options
- *   An array of link options including:
+ * @param array|NULL $link_options
+ *   (Optional) An array of link options including:
  *   - 'link_to_object' : (bool) Include link to object.
  *   - 'link_to_search' : (bool) Include link to search results.
  *   - 'field' : (SOLR Result Field) Result field.
@@ -429,7 +429,7 @@ function islandora_solr_islandora_basic_collection_backend_callable($collection_
  * @return string
  *   The updated display values.
  */
-function islandora_solr_truncate_field_display($display_values, $max_length, $add_ellipsis, $word_safe, $wordsafe_length, $separator, $link_options) {
+function islandora_solr_truncate_field_display($display_values, $max_length, $add_ellipsis, $word_safe, $wordsafe_length, $separator, $link_options = NULL) {
   $updated_display_values = $display_values;
   if (count($updated_display_values) > 0) {
     $mod_path = drupal_get_path('module', 'islandora_solr');
@@ -456,27 +456,39 @@ function islandora_solr_truncate_field_display($display_values, $max_length, $ad
     }
 
     $original_value = implode($separator, $updated_display_values);
-    if (isset($link_options['link_to_object']) && $link_options['link_to_object'] == TRUE) {
-      $original_value = l($original_value, $link_options['url'], $link_options['options']);
+    $truncated_value = implode($separator, $truncated_list);
+    if ($link_options !== NULL) {
+      if (isset($link_options['link_to_object']) && $link_options['link_to_object'] == TRUE) {
+        $original_value = l($original_value, $link_options['url'], $link_options['options']);
+        $truncated_value = l($truncated_value, $link_options['url'], $link_options['options']);
+      }
+      elseif (isset($link_options['link_to_search']) && $link_options['link_to_search'] == TRUE) {
+        $solr_query = format_string('!field:"!value"', array(
+          '!field' => $link_options['field'],
+          '!value' => islandora_solr_lesser_escape($original_value),
+          ));
+        $original_value = l(
+          $original_value,
+          "islandora/search/$solr_query",
+          array(
+            'html' => TRUE,
+          )
+        );
+        $truncated_value = l(
+          $truncated_value,
+          "islandora/search/$solr_query",
+          array(
+            'html' => TRUE,
+          )
+        );
+      }
     }
-    elseif (isset($link_options['link_to_search']) && $link_options['link_to_search'] == TRUE) {
-      $solr_query = format_string('!field:"!value"', array(
-        '!field' => $link_options['field'],
-        '!value' => islandora_solr_lesser_escape($original_value),
-        ));
-      $original_value = l(
-        $original_value,
-        "islandora/search/$solr_query",
-        array(
-          'html' => TRUE,
-        )
-      );
-    }
+
     $updated_display_values
       = "<span class='toggle-wrapper'>" .
       t("<span>!value !separator<a href='#' class='toggler'>Show more</a></span>", array(
         '!separator' => $separator,
-        '!value' => implode($separator, $truncated_list),
+        '!value' => $truncated_value,
       )) .
       t("<span>!original_value !separator<a href='#' class='toggler'>Show less</a></span>", array(
         '!separator' => $separator,


### PR DESCRIPTION
**Jira:** https://jira.duraspace.org/browse/ISLANDORA-1623
# What does this Pull Request do?

Corrects an issue with 'Show More' and 'Show Less' functionality when truncating a default display field and said field is configured to link to an object or search results page.
# How should this be tested?
- Add a default display field of appropriate length
- Click configure
- Select 'Link this field to the object's page. ' or 'Link the value to a Solr search result.'
- Expand Maximum Length field set, and select 'Limit length of whole field'
- Add a Maximum Length less then the characters that would appear in the value of the selected field.
- View an object with said field and length requirements in the search results page. The 'Show More' and 'Show Less' should reveal and hide additional field data.
# Background context:

When links are wrapped in links, the produced HTML gets munged up and produces undesired results.
# Additional Notes:
- **Does this change require documentation to be updated?** No, however additional function documentation has been updated.
- **Does this change add any new dependencies?** No.
- **Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?** No.
- **Could this change impact execution of existing code?** No.

**Tagging:** @jordandukart 

---

Morgan Dawe
_Developer_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**
