### PR TITLE
Islandora 1632

### DIFF
--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -704,6 +704,48 @@ function islandora_solr_admin_settings($form, &$form_state) {
 }
 
 /**
+ * Confirmation for reset solr settings.
+ *
+ * @param array $form
+ *   Array containing all form elements.
+ * @param array $form_state
+ *   The form_state array of the form. Includes the values.
+ *
+ * @return array
+ *   Rendered confirmation form.
+ */
+function islandora_solr_admin_settings_default_confirm_form(array $form, array &$form_state) {
+  $form = confirm_form($form,
+    t('Confirm settings reset to default'),
+    'admin/islandora/search/islandora_solr/settings/',
+    t('Confirm reset settings to default, this cannot be undone.'),
+    t('Continue'),
+    t('Cancel')
+  );
+  return $form;
+}
+
+/**
+ * If user confirms reset solr settings delete settings.
+ *
+ * Iterate through an array of Solr settings and remove the present values,
+ * redirect user back to settings page.
+ *
+ * @param array $form
+ *   Array containing all form elements.
+ * @param array $form_state
+ *   The form_state array of the form. Includes the values.
+ */
+function islandora_solr_admin_settings_default_confirm_form_submit(array $form, array &$form_state) {
+  module_load_include('install', 'islandora_solr');
+  $vars = islandora_solr_search_settings_variables();
+  array_walk($vars, 'variable_del');
+  db_delete('islandora_solr_fields')->execute();
+  drupal_set_message(t('The configuration options have been reset to their default values.'));
+  $form_state['redirect'] = 'admin/islandora/search/islandora_solr/settings/';
+}
+
+/**
  * Generates fields for the admin fields table.
  *
  * First collects values to populate the table, then render the fields.
@@ -1273,16 +1315,7 @@ function _islandora_solr_admin_settings_submit($form, &$form_state) {
       break;
 
     case t('Reset to defaults'):
-      foreach ($form_state['values'] as $key => $value) {
-        variable_del($key);
-      }
-      variable_del('islandora_solr_primary_display');
-      variable_del('islandora_solr_request_handler');
-
-      db_delete('islandora_solr_fields')->execute();
-
-      drupal_set_message(t('The configuration options have been reset to their default values.'));
-      break;
+      $form_state['redirect'] = 'admin/islandora/search/islandora_solr/settings/confirmation';
   }
 
   // Clear caches.

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -352,7 +352,7 @@ function islandora_solr_prepare_solr_results($solr_results) {
               '!field' => $field,
               '!value' => islandora_solr_lesser_escape($original_value),
             ));
-            return l($formatted_value, "islandora/search/$solr_query", array(
+            return l($formatted_value, "islandora/search/" . islandora_solr_replace_slashes($solr_query), array(
               'html' => TRUE,
             ));
           };

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -352,7 +352,7 @@ function islandora_solr_prepare_solr_results($solr_results) {
               '!field' => $field,
               '!value' => islandora_solr_lesser_escape($original_value),
             ));
-            return l($formatted_value, "islandora/search/" . islandora_solr_replace_slashes($solr_query), array(
+            return l($formatted_value, "islandora/search/$solr_query, array(
               'html' => TRUE,
             ));
           };

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -352,7 +352,7 @@ function islandora_solr_prepare_solr_results($solr_results) {
               '!field' => $field,
               '!value' => islandora_solr_lesser_escape($original_value),
             ));
-            return l($formatted_value, "islandora/search/$solr_query, array(
+            return l($formatted_value, "islandora/search/$solr_query", array(
               'html' => TRUE,
             ));
           };

--- a/islandora_solr.install
+++ b/islandora_solr.install
@@ -44,46 +44,22 @@ function islandora_solr_install() {
 
 /**
  * Implements hook_uninstall().
+ *
+ * If making changes to the islandora_solr_admin_settings() form, add
+ * variables to the islandora_solr_serch_settings_variables() array.
  */
 function islandora_solr_uninstall() {
 
   // Removing variables.
-  $variables = array(
+  $variables = array_merge(islandora_solr_search_settings_variables(), array(
     'islandora_solr_url',
-    'islandora_solr_request_handler',
     'islandora_solr_dismax_allowed',
-    'islandora_solr_primary_display',
-    'islandora_solr_primary_display_table',
-    'islandora_solr_secondary_display',
-    'islandora_solr_facet_min_limit',
-    'islandora_solr_facet_soft_limit',
-    'islandora_solr_facet_max_limit',
-    'islandora_solr_search_boolean',
-    'islandora_solr_limit_result_fields',
-    'islandora_solr_num_of_results',
-    'islandora_solr_search_navigation',
-    'islandora_solr_namespace_restriction',
-    'islandora_solr_base_query',
-    'islandora_solr_base_advanced',
-    'islandora_solr_base_sort',
     'islandora_solr_collection_sort',
     'islandora_solr_individual_collection_sorting',
-    'islandora_solr_base_filter',
-    'islandora_solr_query_fields',
-    'islandora_solr_debug_mode',
-    'islandora_solr_content_model_field',
-    'islandora_solr_object_label_field',
-    'islandora_solr_datastream_id_field',
-    'islandora_solr_allow_preserve_filters',
     'islandora_solr_force_update_index_after_object_purge',
-    'islandora_solr_use_ui_qf',
-    'islandora_solr_human_friendly_query_block',
-  );
-  foreach ($variables as $variable) {
-    variable_del($variable);
-  }
+  ));
+  array_walk($variables, 'variable_del');
 }
-
 
 /**
  * Implements hook_schema().
@@ -255,4 +231,48 @@ function islandora_solr_update_7000() {
 function islandora_solr_update_7001() {
   $schema = islandora_solr_schema();
   db_create_table('islandora_solr_collection_sort_strings', $schema['islandora_solr_collection_sort_strings']);
+}
+
+
+/**
+ * List of all variables used for solr settings.
+ *
+ * If making additions to the islandora_solr_admin_settings() form, add
+ * variables to this list. Otherwise refer to hook_uninstall().
+ */
+function islandora_solr_search_settings_variables() {
+  $variables = array(
+    'islandora_solr_result_fields',
+    'islandora_solr_limit_result_fields',
+    'islandora_solr_num_of_results',
+    'islandora_solr_search_navigation',
+    'islandora_solr_sort_fields',
+    'islandora_solr_facet_fields',
+    'islandora_solr_facet_min_limit',
+    'islandora_solr_facet_soft_limit',
+    'iSlandora_solr_facet_max_limit',
+    'islandora_solr_search_fields',
+    'islandora_solr_search_boolean',
+    'islandora_solr_allow_preserve_filters',
+    'islandora_solr_human_friendly_query_block',
+    'islandora_solr_namespace_restriction',
+    'islandora_solr_base_query',
+    'islandora_solr_base_advanced',
+    'islandora_solr_base_sort',
+    'islandora_solr_base_filter',
+    'islandora_solr_query_fields',
+    'islandora_solr_use_ui_qf',
+    'islandora_solr_content_model_field',
+    'islandora_solr_datastream_id_field',
+    'islandora_solr_object_label_field',
+    'islandora_solr_member_of_field',
+    'islandora_solr_member_of_collection_field',
+    'islandora_solr_debug_mode',
+    'islandora_solr_tabs_active_tab',
+    'islandora_solr_primary_display_table',
+    'islandora_solr_secondary_display',
+    'islandora_solr_primary_display',
+    'islandora_solr_request_handler',
+  );
+  return $variables;
 }

--- a/islandora_solr.module
+++ b/islandora_solr.module
@@ -77,6 +77,15 @@ function islandora_solr_menu() {
     'file' => 'includes/admin.inc',
     'type' => MENU_CALLBACK,
   );
+  $items['admin/islandora/search/islandora_solr/settings/confirmation'] = array(
+    'title' => 'Default settings restore',
+    'description' => 'Confirmation form to confirm defualt settings restore',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('islandora_solr_admin_settings_default_confirm_form'),
+    'access arguments' => array('administer islandora solr'),
+    'file' => 'includes/admin.inc',
+    'type' => MENU_CALLBACK,
+  );
   return $items;
 }
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1632
# What does this Pull Request do?

Added a confirmation screen to the islandora solr settings UI when resetting settings to default. Also split the hook_uninstall array of values into a new array for the admin settings, leftover variables remain in hook_uninstall. I noted that if someone was to add variables to the admin form, they would be advised to add them to the new function islandora_solr_admin_settings() which will return an array of all admin form variables.
# How should this be tested?
- Change some values around in the admin/islandora/search/islandora_solr/settings/ form and save changes.
- Click 'reset to default' and confirm.
- Ta-da!
# Interested parties

@rosiel @nhart
