### PR TITLE
Render the label on a negative search facet.

### DIFF
--- a/includes/results.inc
+++ b/includes/results.inc
@@ -512,11 +512,12 @@ class IslandoraSolrResults {
       $filter_split = preg_split(ISLANDORA_SOLR_QUERY_FIELD_VALUE_SPLIT_REGEX, $filter, 2);
       // Trim brackets.
       $filter_split[1] = trim($filter_split[1], "\"");
+      $solr_field = ltrim($filter_split[0], '-');
       // If value is date.
-      if (isset($islandora_solr_query->solrParams['facet.date']) && in_array(ltrim($filter_split[0], '-'), $islandora_solr_query->solrParams['facet.date'])) {
+      if (isset($islandora_solr_query->solrParams['facet.date']) && in_array($solr_field, $islandora_solr_query->solrParams['facet.date'])) {
         // Check date format setting.
         foreach ($this->rangeFacets as $value) {
-          if ($value['solr_field'] == $filter_split[0] && isset($value['solr_field_settings']['date_facet_format']) && !empty($value['solr_field_settings']['date_facet_format'])) {
+          if ($value['solr_field'] == $solr_field && isset($value['solr_field_settings']['date_facet_format']) && !empty($value['solr_field_settings']['date_facet_format'])) {
             $format = $value['solr_field_settings']['date_facet_format'];
           }
         }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1715
# What does this Pull Request do?

Renders the value for a facet triggered via a negative search.
# How should this be tested?

-Navigate to the Solr settings page (admin/islandora/search/islandora_solr/settings)
-Click Facet settings
-Add a range facet of type _dt, a date (for example: mods_originInfo_dateIssued_dt)
-Do not use the date range slider.
-Search for anything
Click the '-' facet link
-Note a warning is no longer thrown and the label displaying the facet is rendered.
# Interested parties

@DiegoPino as maintainer.
