### PR TITLE
7.x template preprocess

### DIFF
--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -61,7 +61,8 @@ function islandora_solr_preprocess_islandora_solr_wrapper(&$variables) {
  *
  * Default template: theme/islandora-solr.tpl.php.
  */
-function islandora_solr_preprocess_islandora_solr(&$variables) {
+function template_preprocess_islandora_solr(&$variables) {
+
   $results = $variables['results'];
   foreach ($results as $key => $result) {
     // Thumbnail.

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -27,7 +27,7 @@
  * @see islandora_solr_theme()
  * @see IslandoraSolrResults::displayResults()
  */
-function islandora_solr_preprocess_islandora_solr_wrapper(&$variables) {
+function template_preprocess_islandora_solr_wrapper(&$variables) {
   global $base_url;
   $variables['base_url'] = $base_url;
 
@@ -89,7 +89,7 @@ function template_preprocess_islandora_solr(&$variables) {
  *
  * Default template: theme/islandora-solr-facet.tpl.php.
  */
-function islandora_solr_preprocess_islandora_solr_facet(&$variables) {
+function template_preprocess_islandora_solr_facet(&$variables) {
   $buckets = $variables['buckets'];
   if ($variables['hidden']) {
     $variables['classes_array'][] = 'hidden';


### PR DESCRIPTION
**JIRA Ticket**: [JIRA Ticket](https://jira.duraspace.org/browse/ISLANDORA-1737)
# What does this Pull Request do?

This pull request renames pre-processing functions in the theme.inc file, allowing for further template variable customization's further down the processing chain.
# What's new?

--islandora_solr_preprocess_islandora_solr_wrapper renamed to template_preprocess_islandora_solr_wrapper

--islandora_solr_preprocess_islandora_solr renamed to template_preprocess_islandora_solr

--islandora_solr_preprocess_islandora_solr_facet renamed to template_preprocess_islandora_solr_facet
# How should this be tested?

Implement a module preprocess or theme preprocess function for any of the previously mentioned renamed preprocess functions, such as {function MYMODULE_preprocess_islandora_solr(&$variables)}. Test that template variables, say in the result set ($variables['results'][{key}]['thumbnail']) can be overridden now. Any template variable previously set in the poorly named preprocess function could not be overridden further down the processing chain.
- View collection list or grid view.
- View search results page.
- View facets block.

Example:
- Does this change require documentation to be updated? No Documentation required.
- Does this change add any new dependencies? No New Dependencies.
- Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No Further modification required.
- Could this change impact execution of existing code? Very unlikely. In fact, the absence of this fix would indicate the template preprocessing functionality has been broken for some time.
# Interested parties

Tag @Islandora/7-x-1-x-committers @jordandukart @DiegoPino
