### PR TITLE
Address ISLANDORA-1772.

### DIFF
--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -663,6 +663,15 @@ function islandora_solr_admin_settings($form, &$form_state) {
     '#description' => t('Dumps Solr queries to the screen for testing. Warning: if you have the Drupal Apache Solr module enabled alongside this one, the debug function will not work.'),
     '#weight' => 6,
   );
+  // Luke timeout.
+  $form['islandora_solr_tabs']['other']['islandora_solr_luke_timeout'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Solr Luke timeout'),
+    '#size' => 10,
+    '#description' => t("Number of seconds to set timeout for retrieving fields from Solr's Luke interface. Increase this if autocomplete fields containing Solr field names time out."),
+    '#default_value' => variable_get('islandora_solr_luke_timeout', '45'),
+    '#required' => TRUE,
+  );
 
   // The content of the popup dialog.
   $form['islandora_solr_admin_dialog'] = array(

--- a/includes/luke.inc
+++ b/includes/luke.inc
@@ -110,7 +110,8 @@ function islandora_solr_get_luke($solr_url = NULL, $field = NULL, $num_terms = 0
     // Need to set a timeout greater than the default 30 seconds as some indexes
     // could contain a lot of fields and the Luke needs longer to respond in
     // kind.
-    $r = drupal_http_request($luke_url, array('timeout' => 45));
+    $timeout = variable_get('islandora_solr_luke_timeout', '45');
+    $r = drupal_http_request($luke_url, array('timeout' => $timeout));
     if ($r->code / 100 === 2) {
       $luke_json = $r->data;
       // Parse JSON.

--- a/islandora_solr.install
+++ b/islandora_solr.install
@@ -58,6 +58,7 @@ function islandora_solr_uninstall() {
     'islandora_solr_collection_sort_block_override',
     'islandora_solr_individual_collection_sorting',
     'islandora_solr_force_update_index_after_object_purge',
+    'islandora_solr_luke_timeout',
   ));
   array_walk($variables, 'variable_del');
 }

--- a/islandora_solr.install
+++ b/islandora_solr.install
@@ -58,7 +58,6 @@ function islandora_solr_uninstall() {
     'islandora_solr_collection_sort_block_override',
     'islandora_solr_individual_collection_sorting',
     'islandora_solr_force_update_index_after_object_purge',
-    'islandora_solr_luke_timeout',
   ));
   array_walk($variables, 'variable_del');
 }

--- a/islandora_solr.install
+++ b/islandora_solr.install
@@ -275,6 +275,7 @@ function islandora_solr_search_settings_variables() {
     'islandora_solr_secondary_display',
     'islandora_solr_primary_display',
     'islandora_solr_request_handler',
+    'islandora_solr_luke_timeout',
   );
   return $variables;
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1772
# What does this Pull Request do?

Adds an admin option to adjust the HTTP timeout for calls to Solr's Luke interface. This will let admins increase the timeout value from the currently hard-coded 45 seconds.
# What's new?

A new field in the Solr Settings > Other tab that contains the timeout value. 45 seconds is the default value, which is identical to the current hard-coded value, so not adjusting this setting should have no side effects.
# How should this be tested?
1. In the Solr Settings > Other tab, set the Solr Luke timeout value to 2 seconds
2. In Solr Settings > Default Display Settings, enter something in the "Enter another item" autocomplete field under Display Fields. The autocomplete should time out quickly (in 2 seconds)
3. Back in the Solr Settings > Other tab, update the Solr Luke timeout value to a high value, like 60 seconds.
4. Repeat step 2.
5. The autocomplete should _not_ time out.
# Additional Notes:
- Does this change require documentation to be updated? Probably not, since the help text under the field should be fairly complete.
- Does this change add any new dependencies? No.
- Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No.
- Could this change impact execution of existing code? Could, but it is fairly minor so unanticipated side effects are unlikely.
# Interested parties

@jordandukart and @DiegoPino as component managers, @Islandora/7-x-1-x-committers for good measure.
