### PR TITLE
Correct database schema

### DIFF
--- a/islandora_solr.install
+++ b/islandora_solr.install
@@ -234,6 +234,54 @@ function islandora_solr_update_7001() {
   db_create_table('islandora_solr_collection_sort_strings', $schema['islandora_solr_collection_sort_strings']);
 }
 
+/**
+ * Fix the table islandora_solr_collection_sort_strings, if possible.
+ */
+function islandora_solr_update_7002() {
+  module_load_include('inc', 'islandora', 'includes/utilities');
+  $schema = islandora_solr_schema();
+  $results = db_select('islandora_solr_collection_sort_strings', 'c')
+    ->fields('c', array('collection_pid', 'sort_string'))
+    ->execute();
+
+  $is_empty = function($o) {
+    return (empty($o) || trim($o) == FALSE);
+  };
+
+  while (FALSE !== ($row = $results->fetchAssoc())) {
+    if (!islandora_is_valid_pid($row['collection_pid']) || $is_empty($row['sort_string'])) {
+      watchdog(
+        'islandora_solr',
+        'There was an empty sort string or invalid pid in the islandora_solr_collection_sort_strings table, you must manually fix this table. See ticket for more information.',
+        array(),
+        WATCHDOG_ERROR,
+        l(t('ISLANDORA-1786'), 'https://jira.duraspace.org/browse/ISLANDORA-1786', array('external' => TRUE))
+      );
+
+      throw new DrupalUpdateException(
+        t(
+          'There was an empty sort string or invalid pid in the islandora_solr_collection_sort_strings table, you must manually fix this table. See !ticket for more information',
+          array('!ticket' => 'https://jira.duraspace.org/browse/ISLANDORA-1786')
+        )
+      );
+    }
+  }
+
+  db_drop_primary_key('islandora_solr_collection_sort_strings');
+  db_change_field(
+    'islandora_solr_collection_sort_strings',
+    'collection_pid',
+    'collection_pid',
+    $schema['islandora_solr_collection_sort_strings']['fields']['collection_pid']
+  );
+  db_change_field(
+    'islandora_solr_collection_sort_strings',
+    'sort_string',
+    'sort_string',
+    $schema['islandora_solr_collection_sort_strings']['fields']['sort_string']
+  );
+  db_add_primary_key('islandora_solr_collection_sort_strings', array('collection_pid'));
+}
 
 /**
  * List of all variables used for solr settings.

--- a/islandora_solr.install
+++ b/islandora_solr.install
@@ -245,7 +245,7 @@ function islandora_solr_update_7002() {
     ->execute();
 
   $is_empty = function($o) {
-    return (empty($o) || trim($o) == FALSE);
+    return (empty($o) || !trim($o));
   };
 
   while (FALSE !== ($row = $results->fetchAssoc())) {

--- a/islandora_solr.install
+++ b/islandora_solr.install
@@ -104,13 +104,13 @@ function islandora_solr_schema() {
       'collection_pid' => array(
         'type' => 'varchar',
         'length' => 255,
-        'not_null' => TRUE,
+        'not null' => TRUE,
         'description' => 'The collection PID',
       ),
       'sort_string' => array(
         'type' => 'text',
         'size' => 'medium',
-        'not_null' => TRUE,
+        'not null' => TRUE,
         'description' => 'Sort string for the collection',
       ),
     ),


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1786
# What does this Pull Request do?

Corrects the Drupal database table schema.
# What's new?

Changes "not_null" to "not null" per the [Drupal Database Schema API](https://api.drupal.org/api/drupal/includes!database!schema.inc/group/schemaapi/7.x)
# How should this be tested?

This seems to be dependant on your MySQL version or server configuration. 

I could **not** duplicate it with vagrant (5.5.44-0ubuntu0.14.04.1 (Ubuntu))
but it occurred using our campus MySQL servers (5.7.11-enterprise-commercial-advanced-log MySQL Enterprise Server - Advanced Edition (Commercial))

It could also perhaps be to a configuration settings about the assumption of NULLs?

It appeared by, before the PR.
On Admin -> Islandora -> Solution Pack Config -> Collection Solution Pack
1. Choose _Solr_ for **Display Generation**.
2. Choose _Allow individual sort strings per-collection_

Go to a Collection, choose Manage.
Then click on the _Collection_ tab and see an error.

**Apply the PR**
Do database updates either at `http://localhost/update.php` or `drush updatedb`

Go to a Collection, choose Manage.
Then click on the _Collection_ tab and fixed.

Example:
- Does this change require documentation to be updated? no
- Does this change add any new dependencies? no
- Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
- Could this change impact execution of existing code? no
# Interested parties

@jordandukart, @DiegoPino as maintainers
