### PR TITLE
Utility function for removing base filters

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -538,11 +538,11 @@ function islandora_solr_is_date_field($solr_field) {
 /**
  * Removes the base filters from the Solr params if they exist.
  *
- * @var array $params
- *    The Solr params array.
+ * @param array $params
+ *   The Solr params array.
  *
  * @return array
- *    The $params array minus any base filters.
+ *   The $params array minus any base filters.
  */
 function islandora_solr_remove_base_filters(array $params) {
   if (is_array($params) && isset($params['fq'])) {

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -534,3 +534,20 @@ function islandora_solr_is_date_field($solr_field) {
   }
   return FALSE;
 }
+
+/**
+ * Removes the base filters from the Solr params if they exist.
+ *
+ * @var array $params
+ *    The Solr params array.
+ *
+ * @return array
+ *    The $params array minus any base filters.
+ */
+function islandora_solr_remove_base_filters(array $params) {
+  if (is_array($params) && isset($params['fq'])) {
+    $base_filters = preg_split("/\\r\\n|\\n|\\r/", variable_get('islandora_solr_base_filter', ''), -1, PREG_SPLIT_NO_EMPTY);
+    $params['fq'] = array_diff($params['fq'], $base_filters);
+  }
+  return $params;
+}

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -545,7 +545,7 @@ function islandora_solr_is_date_field($solr_field) {
  *   The $params array minus any base filters.
  */
 function islandora_solr_remove_base_filters(array $params) {
-  if (is_array($params) && isset($params['fq'])) {
+  if (isset($params['fq'])) {
     $base_filters = preg_split("/\\r\\n|\\n|\\r/", variable_get('islandora_solr_base_filter', ''), -1, PREG_SPLIT_NO_EMPTY);
     $params['fq'] = array_diff($params['fq'], $base_filters);
   }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1838
# What does this Pull Request do?

If you set a base filter for Solr through the UI. You can then use the IslandoraSolrQueryProcessor to build your queries with appropriate XACML restrictions included but **NOT** those base filters.

For example:
We have a base filter of `-RELS_EXT_hasModel_uri_ms:"info:fedora/islandora:newspaperIssueCModel"` so newspaper issues (which aggregate the page OCR) don't display in search results.

But I wanted to use the `IslandoraSolrQueryProcessor` to generate a list of issues via Solr. To do this I had to remove the above filter from the parameters. 

I could keep this function in a separate module, but I have multiple uses for it and those places already depend on Islandora Solr. So it seemed the best place to avoid duplicating code.
# What's new?

Nothing, this function is not referenced in internal code (which might be a reason not to include it). But could be used by developers that might need this type of functionality.
# How should this be tested?

n/a
# Additional Notes:

Example:
- Does this change require documentation to be updated? no
- Does this change add any new dependencies? no
- Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
- Could this change impact execution of existing code? no
# Interested parties

@jordandukart -  I'm not sure if it is acceptable to add this type of code to the core. So let me know what you think.
