### PR TITLE
Allow for date fields to have a date_format in facets.

### DIFF
--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -1825,7 +1825,7 @@ function islandora_solr_admin_settings_result_fields($form, &$form_state, $varia
       '#type' => 'textfield',
       '#title' => t('Date format'),
       '#default_value' => isset($values['date_format']) ? $values['date_format'] : '',
-      '#description' => t('The format of the date, as it will be displayed in the search results. Use <a href="!url" target="_blank">PHP date()</a> formatting.', array('!url' => 'http://php.net/manual/function.date.php')),
+      '#description' => t('The format of the date, as it will be displayed in the search results. Use <a href="!url" target="_blank">PHP date()</a> formatting. Works best when the date format matches the granularity of the source data. Otherwise it is possible that there will be duplicates displayed.', array('!url' => 'http://php.net/manual/function.date.php')),
     );
   }
 
@@ -1998,7 +1998,7 @@ function islandora_solr_admin_settings_facet_fields($form, &$form_state, $variab
       '#type' => 'textfield',
       '#title' => t('Date format'),
       '#default_value' => $values['date_facet_format'],
-      '#description' => t('The format of the date, as it will be displayed in the facet block. Use <a href="!url">PHP date()</a> formatting.', array('!url' => 'http://php.net/manual/function.date.php')),
+      '#description' => t('The format of the date, as it will be displayed in the facet block. Use <a href="!url">PHP date()</a> formatting. Works best when the date format matches the granularity of the source data. Otherwise it is possible that there will be duplicates displayed.', array('!url' => 'http://php.net/manual/function.date.php')),
     );
 
     $form['options']['range_facet'] = array(

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -1994,6 +1994,13 @@ function islandora_solr_admin_settings_facet_fields($form, &$form_state, $variab
       'date_filter_datepicker_enabled' => 0,
       'date_filter_datepicker_range' => '-100:+3',
     );
+    $form['options']['date_facet_format'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Date format'),
+      '#default_value' => $values['date_facet_format'],
+      '#description' => t('The format of the date, as it will be displayed in the facet block. Use <a href="!url">PHP date()</a> formatting.', array('!url' => 'http://lucene.apache.org/solr/api/org/apache/solr/util/DateMathParser.html')),
+    );
+
     $form['options']['range_facet'] = array(
       '#type' => 'fieldset',
       '#id' => 'range-facet-wrapper',
@@ -2044,13 +2051,6 @@ function islandora_solr_admin_settings_facet_fields($form, &$form_state, $variab
       '#default_value' => $values['range_facet_gap'],
       '#description' => t('The size of each date range, expressed as an interval to be added to the lower bound using the <a href="!url">DateMathParser</a> syntax.', array('!url' => 'http://lucene.apache.org/solr/api/org/apache/solr/util/DateMathParser.html')),
     );
-    $form['options']['range_facet']['wrapper']['date_facet_format'] = array(
-      '#type' => 'textfield',
-      '#title' => t('Date format'),
-      '#default_value' => $values['date_facet_format'],
-      '#description' => t('The format of the date, as it will be displayed in the facet block. Use <a href="!url">PHP date()</a> formatting.', array('!url' => 'http://lucene.apache.org/solr/api/org/apache/solr/util/DateMathParser.html')),
-    );
-
     // Range slider.
     $form['options']['range_facet']['wrapper']['range_slider'] = array(
       '#type' => 'fieldset',

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -1998,7 +1998,7 @@ function islandora_solr_admin_settings_facet_fields($form, &$form_state, $variab
       '#type' => 'textfield',
       '#title' => t('Date format'),
       '#default_value' => $values['date_facet_format'],
-      '#description' => t('The format of the date, as it will be displayed in the facet block. Use <a href="!url">PHP date()</a> formatting.', array('!url' => 'http://lucene.apache.org/solr/api/org/apache/solr/util/DateMathParser.html')),
+      '#description' => t('The format of the date, as it will be displayed in the facet block. Use <a href="!url">PHP date()</a> formatting.', array('!url' => 'http://php.net/manual/function.date.php')),
     );
 
     $form['options']['range_facet'] = array(

--- a/includes/db.inc
+++ b/includes/db.inc
@@ -238,6 +238,20 @@ function islandora_solr_get_range_facets() {
 }
 
 /**
+ * Return non-range facets with date formatting enabled.
+ */
+function islandora_solr_get_date_format_facets() {
+  $records = islandora_solr_get_fields('facet_fields', TRUE, FALSE);
+  $date_format = array();
+  foreach ($records as $values) {
+    if (!isset($values['solr_field_settings']['range_facet_select']) && isset($values['solr_field_settings']['date_facet_format'])) {
+      $date_format[$values['solr_field']] = $values;
+    }
+  }
+  return $date_format;
+}
+
+/**
  * Function used with optional i18n_string integration.
  */
 function islandora_solr_translate_field_labels(array &$records) {

--- a/includes/results.inc
+++ b/includes/results.inc
@@ -870,12 +870,15 @@ class IslandoraSolrFacets {
     $facet_field = $this->facet_field;
     $facet_results = array();
     module_load_include('inc', 'islandora_solr', 'includes/utilities');
+    // It's possible that there could be a facet that's a date field
+    // that's not a range.
+    $date_format = isset($this->settings['solr_field_settings']['date_facet_format']) ? $date_format = $this->settings['solr_field_settings']['date_facet_format'] : FALSE;
     foreach ($results as $bucket => $count) {
       $facet_results[] = array(
         'count' => $count,
         'filter' => islandora_solr_lesser_escape($facet_field) . ':"' .
         islandora_solr_facet_escape($bucket) . '"',
-        'bucket' => $bucket,
+        'bucket' => $date_format ? format_date(strtotime($bucket), 'custom', $date_format) : $bucket,
       );
     }
     return $facet_results;

--- a/includes/results.inc
+++ b/includes/results.inc
@@ -872,7 +872,7 @@ class IslandoraSolrFacets {
     module_load_include('inc', 'islandora_solr', 'includes/utilities');
     // It's possible that there could be a facet that's a date field
     // that's not a range.
-    $date_format = isset($this->settings['solr_field_settings']['date_facet_format']) ? $date_format = $this->settings['solr_field_settings']['date_facet_format'] : FALSE;
+    $date_format = isset($this->settings['solr_field_settings']['date_facet_format']) ? $this->settings['solr_field_settings']['date_facet_format'] : FALSE;
     foreach ($results as $bucket => $count) {
       $facet_results[] = array(
         'count' => $count,

--- a/includes/results.inc
+++ b/includes/results.inc
@@ -17,6 +17,7 @@ class IslandoraSolrResults {
   public $allSubsArray = array();
   public $islandoraSolrQueryProcessor;
   public $rangeFacets = array();
+  public $dateFormatFacets = array();
 
   /**
    * Constructor.
@@ -24,6 +25,7 @@ class IslandoraSolrResults {
   public function __construct() {
     $this->prepFieldSubstitutions();
     $this->rangeFacets = islandora_solr_get_range_facets();
+    $this->dateFormatFacets = islandora_solr_get_date_format_facets();
   }
 
   /**
@@ -527,6 +529,10 @@ class IslandoraSolrResults {
         $filter_str = trim($filter_str, ']');
         $filter_array = explode(' TO ', $filter_str);
         $filter_split[1] = format_date(strtotime(trim($filter_array[0])) + (60 * 60 * 24), 'custom', $format) . ' - ' . format_date(strtotime(trim($filter_array[1])) + (60 * 60 * 24), 'custom', $format);
+      }
+      elseif (isset($this->dateFormatFacets[$solr_field])) {
+        $format = $this->dateFormatFacets[$solr_field]['solr_field_settings']['date_facet_format'];
+        $filter_split[1] = format_date(strtotime(stripslashes($filter_split[1])), 'custom', $format);
       }
       $filter_string = $filter_split[1];
     }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1840

# What does this Pull Request do?
When displaying a date field that it's a facet having a human readable label is more user friendly as opposed to a ISO8601 datestamp.

# What's new?
Expose the format_date for all date fields in facets and don't constrain it just to date range facets. .

# How should this be tested?
* Create a facet field from a date
* Ensure that it's not a range field
* Enter a date format such as `Y-m-d`
* Search for some content, note how the formatted date is displayed as opposed to the full timestamp 

# Additional Notes:
Bubbling up the date formatter won't have any impact in the stored settings as the form isn't `#tree`ed.

# Interested parties:
@Islandora/7-x-1-x-committers as I am maintainer.

