### PR TITLE
Allow facet level sorting

### DIFF
--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -1998,14 +1998,14 @@ function islandora_solr_admin_settings_facet_fields($form, &$form_state, $variab
     '#description' => t('A human-readable name.'),
   );
   $form['options']['sort_by'] = array(
-    '#type' => 'select',
+    '#type' => 'radios',
     '#title' => t('Sort by'),
     '#default_value' => isset($values['sort_by']) ? $values['sort_by'] : 'count',
     '#options' => array(
-      'count' => t('Counts'),
-      'index' => t('Labels'),
+      'count' => t('Count of facet (numerically)'),
+      'index' => t('Text labels (alphabetically)'),
     ),
-    '#description' => t('Facets can be sorted by label values or the count.'),
+    '#description' => t('Facets can be sorted by text label or the count of the facet. This does not change how the facet is created, only the order it is displayed in.'),
   );
 
   if (islandora_solr_is_date_field($solr_field)) {

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -1656,6 +1656,7 @@ function _islandora_solr_handle_solr_field_settings($solr_field_settings = NULL,
           'date_filter_datepicker_enabled',
           'date_filter_datepicker_range',
           'pid_object_label',
+          'sort_by',
         ));
         $relevant_values = array_intersect_key($solr_field_settings, $fields);
         $relevant_values['label'] = isset($relevant_values['label']) ?
@@ -1995,6 +1996,16 @@ function islandora_solr_admin_settings_facet_fields($form, &$form_state, $variab
     '#title' => t('Label'),
     '#default_value' => isset($values['label']) ? $values['label'] : '',
     '#description' => t('A human-readable name.'),
+  );
+  $form['options']['sort_by'] = array(
+    '#type' => 'select',
+    '#title' => t('Sort by'),
+    '#default_value' => isset($values['sort_by']) ? $values['sort_by'] : 'count',
+    '#options' => array(
+      'count' => t('Counts'),
+      'index' => t('Labels'),
+    ),
+    '#description' => t('Facets can be sorted by label values or the count.'),
   );
 
   if (islandora_solr_is_date_field($solr_field)) {

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -2005,7 +2005,7 @@ function islandora_solr_admin_settings_facet_fields($form, &$form_state, $variab
       'count' => t('Count of facet (numerically)'),
       'index' => t('Text labels (alphabetically)'),
     ),
-    '#description' => t('Facets can be sorted by text label or the count of the facet. This does not change how the facet is created, only the order it is displayed in.'),
+    '#description' => t('Facets can be sorted by text label or the count of the facet. If you sort by text labels AND replace PID with object label your sort order is not guaranteed.'),
   );
 
   if (islandora_solr_is_date_field($solr_field)) {

--- a/includes/query_processor.inc
+++ b/includes/query_processor.inc
@@ -181,7 +181,7 @@ class IslandoraSolrQueryProcessor {
     $this->solrStart = max(0, $start_page) * $this->solrLimit;
 
     // Set facet parameters.
-    $facet_array = islandora_solr_get_fields('facet_fields');
+    $facet_array = islandora_solr_get_fields('facet_fields', TRUE, FALSE, TRUE);
     $facet_fields = implode(",", array_keys($facet_array));
 
     // Set params.
@@ -235,6 +235,19 @@ class IslandoraSolrQueryProcessor {
 
       $params_array = array_merge($params_array, $params_date_facets);
     }
+
+    // Determine the default facet sort order.
+    // https://cwiki.apache.org/confluence/display/solr/Faceting#Faceting-Thefacet.sortParameter
+    $default_sort = (variable_get('islandora_solr_facet_max_limit', '20') <= 0 ? 'index' : 'count');
+
+    $facet_sort_array = array();
+    foreach (array_merge($facet_array, $facet_dates) as $key => $value) {
+      if (isset($value['solr_field_settings']['sort_by']) && $value['solr_field_settings']['sort_by'] != $default_sort) {
+        // If the sort doesn't match default then specify it in the parameters.
+        $facet_sort_array["f.{$key}.facet.sort"] = check_plain($value['solr_field_settings']['sort_by']);
+      }
+    }
+    $params_array = array_merge($params_array, $facet_sort_array);
 
     // Highlighting.
     $highlighting_array = islandora_solr_get_snippet_fields();

--- a/includes/query_processor.inc
+++ b/includes/query_processor.inc
@@ -237,7 +237,6 @@ class IslandoraSolrQueryProcessor {
     }
 
     // Determine the default facet sort order.
-    // https://cwiki.apache.org/confluence/display/solr/Faceting#Faceting-Thefacet.sortParameter
     $default_sort = (variable_get('islandora_solr_facet_max_limit', '20') <= 0 ? 'index' : 'count');
 
     $facet_sort_array = array();

--- a/includes/results.inc
+++ b/includes/results.inc
@@ -854,17 +854,6 @@ class IslandoraSolrFacets {
   }
 
   /**
-   *
-   * @return mixed
-   */
-  public function getSortOrder() {
-    if (isset($this->settings['solr_field_settings']['sort_by'])) {
-      return $this->settings['solr_field_settings']['sort_by'];
-    }
-    return "count";
-  }
-
-  /**
    * Get date format.
    *
    * Finds the date formatting settings from user configuration.

--- a/includes/results.inc
+++ b/includes/results.inc
@@ -1021,11 +1021,7 @@ class IslandoraSolrFacets {
       $link['count'] = $count;
       $link['link_plus'] = '<a' . drupal_attributes($attributes['plus']['attr']) . '>+</a>';
       $link['link_minus'] = '<a' . drupal_attributes($attributes['minus']['attr']) . '>-</a>';
-      $buckets[$bucket] = $link;
-    }
-
-    if (isset($this->settings['solr_field_settings']['sort_by']) && $this->settings['solr_field_settings']['sort_by'] == 'index') {
-      ksort($buckets);
+      $buckets[] = $link;
     }
 
     // Show more link.

--- a/includes/results.inc
+++ b/includes/results.inc
@@ -854,6 +854,17 @@ class IslandoraSolrFacets {
   }
 
   /**
+   *
+   * @return mixed
+   */
+  public function getSortOrder() {
+    if (isset($this->settings['solr_field_settings']['sort_by'])) {
+      return $this->settings['solr_field_settings']['sort_by'];
+    }
+    return "count";
+  }
+
+  /**
    * Get date format.
    *
    * Finds the date formatting settings from user configuration.
@@ -1021,7 +1032,11 @@ class IslandoraSolrFacets {
       $link['count'] = $count;
       $link['link_plus'] = '<a' . drupal_attributes($attributes['plus']['attr']) . '>+</a>';
       $link['link_minus'] = '<a' . drupal_attributes($attributes['minus']['attr']) . '>-</a>';
-      $buckets[] = $link;
+      $buckets[$bucket] = $link;
+    }
+
+    if (isset($this->settings['solr_field_settings']['sort_by']) && $this->settings['solr_field_settings']['sort_by'] == 'index') {
+      ksort($buckets);
     }
 
     // Show more link.


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1337

https://groups.google.com/forum/#!topic/islandora/-sO_VrHBIQg

# What does this Pull Request do?

Add a configuration option to facets to allow you to change the sort order from by count to by labels.

# What's new?

New `solr_field_settings` parameter `sort_by` with either **count** or **index** (_count_ is default).

# How should this be tested?

1. Apply PR.
2. Make a facet with some values for testing. Leave **Sort By** as `Counts`.
3. Do search, see normal facet ordering.
4. Edit the facet and change **Sort By** to `Labels`. Save settings.
5. Re-run search and see facets ordered by labels.

Example:
* Does this change require documentation to be updated? There is not much documentation about Facets, so I guess no.
* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? No

# Interested parties
@DiegoPino (as he was working Islandora-1337)

