### PR TITLE
Change messages to use theme for images.

### DIFF
--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains all administration related functionality
+ * Contains all administration related functionality.
  */
 
 /**
@@ -10,7 +10,6 @@
  */
 function islandora_solr_admin_index_settings($form, &$form_state) {
   // Add admin form CSS.
-
   $form['#attached'] = array(
     'css' => array(
       drupal_get_path('module', 'islandora_solr') . '/css/islandora_solr.admin.css',
@@ -38,11 +37,11 @@ function islandora_solr_admin_index_settings($form, &$form_state) {
     $handler = !empty($form_state['values']['islandora_solr_request_handler']) ? $form_state['values']['islandora_solr_request_handler'] : variable_get('islandora_solr_request_handler', FALSE);
 
     if (strpos($solr_url, 'https://') !== FALSE && strpos($solr_url, 'https://') == 0) {
-      $confirmation_message = format_string('<img src="@image_url"/>!message', array(
-        // XXX: Use of url() for static image may result in broken images.
-        '@image_url' => url('misc/watchdog-error.png'),
-        '!message' => t('Islandora does not support SSL connections to Solr.'),
-      ));
+      $confirmation_message = theme('image', array(
+        'path' => 'misc/watchdog-error.png',
+        'alt' => check_plain('Unsupported protocol'),
+            )) .
+        t('Islandora does not support SSL connections to Solr.');
       $solr_avail = FALSE;
     }
     else {
@@ -57,29 +56,29 @@ function islandora_solr_admin_index_settings($form, &$form_state) {
       }
       // Get confirmation message.
       if ($solr_avail) {
-        $confirmation_message = format_string('<img src="@image_url"/>!message', array(
-          // XXX: Use of url() for static image may result in broken images.
-          '@image_url' => url('misc/watchdog-ok.png'),
-          '!message' => t('Successfully connected to Solr server at !link. <sub>(!ms ms)</sub>', array(
-              '!link' => l($solr_url, islandora_solr_check_http($solr_url), array(
-                'attributes' => array(
-                  'target' => '_blank',
-                ),
-              )),
-              '!ms' => number_format($solr_avail, 2),
+        $confirmation_message = theme('image', array(
+          'path' => 'misc/watchdog-ok.png',
+          'alt' => check_plain('Connection successful'),
+        )) .
+        t('Successfully connected to Solr server at !link. <sub>(!ms ms)</sub>', array(
+          '!link' => l($solr_url, islandora_solr_check_http($solr_url), array(
+            'attributes' => array(
+              'target' => '_blank',
+            ),
           )),
+          '!ms' => number_format($solr_avail, 2),
         ));
       }
       else {
-        $confirmation_message = format_string('<img src="@image_url"/>!message', array(
-          // XXX: Use of url() for static image may result in broken images.
-          '@image_url' => url('misc/watchdog-error.png'),
-          '!message' => t('Unable to connect to Solr server at !link.', array(
-              '!link' => l($solr_url, islandora_solr_check_http($solr_url), array(
-                'attributes' => array(
-                  'target' => '_blank',
-                ),
-              )),
+        $confirmation_message = theme('image', array(
+          'path' => 'misc/watchdog-error.png',
+          'alt' => check_plain('Error connecting to Solr'),
+        )) .
+        t('Unable to connect to Solr server at !link.', array(
+          '!link' => l($solr_url, islandora_solr_check_http($solr_url), array(
+            'attributes' => array(
+              'target' => '_blank',
+            ),
           )),
         ));
       }

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -37,11 +37,10 @@ function islandora_solr_admin_index_settings($form, &$form_state) {
     $handler = !empty($form_state['values']['islandora_solr_request_handler']) ? $form_state['values']['islandora_solr_request_handler'] : variable_get('islandora_solr_request_handler', FALSE);
 
     if (strpos($solr_url, 'https://') !== FALSE && strpos($solr_url, 'https://') == 0) {
-      $confirmation_message = theme('image', array(
-        'path' => 'misc/watchdog-error.png',
-        'alt' => check_plain('Unsupported protocol'),
-            )) .
-        t('Islandora does not support SSL connections to Solr.');
+      $confirmation_message = format_string('<img src="@image_url"/>!message', array(
+        '@image_url' => file_create_url('misc/watchdog-error.png'),
+        '!message' => t('Islandora does not support SSL connections to Solr.'),
+      ));
       $solr_avail = FALSE;
     }
     else {
@@ -56,29 +55,27 @@ function islandora_solr_admin_index_settings($form, &$form_state) {
       }
       // Get confirmation message.
       if ($solr_avail) {
-        $confirmation_message = theme('image', array(
-          'path' => 'misc/watchdog-ok.png',
-          'alt' => check_plain('Connection successful'),
-        )) .
-        t('Successfully connected to Solr server at !link. <sub>(!ms ms)</sub>', array(
-          '!link' => l($solr_url, islandora_solr_check_http($solr_url), array(
-            'attributes' => array(
-              'target' => '_blank',
-            ),
+        $confirmation_message = format_string('<img src="@image_url"/>!message', array(
+          '@image_url' => file_create_url('misc/watchdog-ok.png'),
+          '!message' => t('Successfully connected to Solr server at !link. <sub>(!ms ms)</sub>', array(
+            '!link' => l($solr_url, islandora_solr_check_http($solr_url), array(
+              'attributes' => array(
+                'target' => '_blank',
+              ),
+            )),
+            '!ms' => number_format($solr_avail, 2),
           )),
-          '!ms' => number_format($solr_avail, 2),
         ));
       }
       else {
-        $confirmation_message = theme('image', array(
-          'path' => 'misc/watchdog-error.png',
-          'alt' => check_plain('Error connecting to Solr'),
-        )) .
-        t('Unable to connect to Solr server at !link.', array(
-          '!link' => l($solr_url, islandora_solr_check_http($solr_url), array(
-            'attributes' => array(
-              'target' => '_blank',
-            ),
+        $confirmation_message = format_string('<img src="@image_url"/>!message', array(
+          '@image_url' => file_create_url('misc/watchdog-error.png'),
+          '!message' => t('Unable to connect to Solr server at !link.', array(
+            '!link' => l($solr_url, islandora_solr_check_http($solr_url), array(
+              'attributes' => array(
+                'target' => '_blank',
+              ),
+            )),
           )),
         ));
       }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1523

# What does this Pull Request do?

Replaces use of `url()` in Solr settings confirmation with `theme('image',...`

# How should this be tested?

Setup your site to use more than one language. I did
1. Enable Locale and Content translation
1. Install internationalization
1. Add a second language and a language selection method of "prefix".

Then view your site using a language prefix (ie. http://localhost:8000/fr) and go to the Islandora Solr settings page. The green checkmark or red X image should be broken because they will reference `/<prefix>/misc/watchdog-ok.png` or  `/<prefix>/misc/watchdog-error.png`.

Apply this PR and the image should display correctly.

# Additional Notes:

Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@ppound or @Islandora/7-x-1-x-committers
