### PR TITLE
Updated default regex in lucene escape.

### DIFF
--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -1088,7 +1088,7 @@ function islandora_solr_admin_breadcrumbs_settings(array $form, array &$form_sta
   $form['islandora_solr_breadcrumbs_admin']['islandora_solr_breadcrumbs_parent_fields'] = array(
     '#type' => 'textarea',
     '#title' => t('Solr Parent Fields'),
-    '#description' => t('A list of Solr fields containing the PIDs of parent objects, 
+    '#description' => t('A list of Solr fields containing the PIDs of parent objects,
     one per line. Will search top to bottom and stop on the first hit.'),
     '#default_value' => variable_get('islandora_solr_breadcrumbs_parent_fields', "RELS_EXT_isMemberOfCollection_uri_ms\r\nRELS_EXT_isMemberOf_uri_ms"),
   );

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -559,7 +559,7 @@ function islandora_solr_admin_settings($form, &$form_state) {
     '#title' => t('Default regular expression evaluated on search term'),
     '#default_value' => variable_get('islandora_solr_advanced_search_block_lucene_regex_default', ISLANDORA_SOLR_QUERY_FACET_LUCENE_ESCAPE_REGEX_DEFAULT),
     '#description' => t(
-      "The default regular expression, used to escape characters when found in search terms. Defaults to @regex",
+      'The default regular expression, used to escape characters when found in search terms. Defaults to @regex',
       array(
         '@regex' => ISLANDORA_SOLR_QUERY_FACET_LUCENE_ESCAPE_REGEX_DEFAULT,
       )
@@ -1088,7 +1088,7 @@ function islandora_solr_admin_breadcrumbs_settings(array $form, array &$form_sta
   $form['islandora_solr_breadcrumbs_admin']['islandora_solr_breadcrumbs_parent_fields'] = array(
     '#type' => 'textarea',
     '#title' => t('Solr Parent Fields'),
-    '#description' => t('A list of Solr fields containing the PIDs of parent objects, 
+    '#description' => t('A list of Solr fields containing the PIDs of parent objects,
     one per line. Will search top to bottom and stop on the first hit.'),
     '#default_value' => variable_get('islandora_solr_breadcrumbs_parent_fields', "RELS_EXT_isMemberOfCollection_uri_ms\r\nRELS_EXT_isMemberOf_uri_ms"),
   );

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -559,7 +559,7 @@ function islandora_solr_admin_settings($form, &$form_state) {
     '#title' => t('Default regular expression evaluated on search term'),
     '#default_value' => variable_get('islandora_solr_advanced_search_block_lucene_regex_default', ISLANDORA_SOLR_QUERY_FACET_LUCENE_ESCAPE_REGEX_DEFAULT),
     '#description' => t(
-      'The default regular expression, used to escape characters when found in search terms. Defaults to @regex',
+      "The default regular expression, used to escape characters when found in search terms. Defaults to @regex",
       array(
         '@regex' => ISLANDORA_SOLR_QUERY_FACET_LUCENE_ESCAPE_REGEX_DEFAULT,
       )

--- a/islandora_solr.module
+++ b/islandora_solr.module
@@ -9,7 +9,7 @@ define('ISLANDORA_SOLR_SEARCH_PATH', 'islandora/search');
 define('ISLANDORA_SOLR_QUERY_SPLIT_REGEX', '/(?<!\\\\) /');
 define('ISLANDORA_SOLR_QUERY_FIELD_VALUE_SPLIT_REGEX', '/(?<!\\\\):/');
 
-const ISLANDORA_SOLR_QUERY_FACET_LUCENE_ESCAPE_REGEX_DEFAULT = '/(\+|-|&&|\|\||!|\(|\)|\{|\}|\[|\]|\^|~|\*|\?|\:|\"|\\)/';
+const ISLANDORA_SOLR_QUERY_FACET_LUCENE_ESCAPE_REGEX_DEFAULT = '/(\+|-|&&|\|\||!|\(|\)|\{|\}|\[|\]|\^|~|\*|\?|\:|\"|\\\\)/';
 
 const ISLANDORA_SOLR_FACET_BUCKET_CLASSES_HOOK_BASE = 'islandora_solr_facet_bucket_classes';
 

--- a/islandora_solr.module
+++ b/islandora_solr.module
@@ -9,7 +9,7 @@ define('ISLANDORA_SOLR_SEARCH_PATH', 'islandora/search');
 define('ISLANDORA_SOLR_QUERY_SPLIT_REGEX', '/(?<!\\\\) /');
 define('ISLANDORA_SOLR_QUERY_FIELD_VALUE_SPLIT_REGEX', '/(?<!\\\\):/');
 
-const ISLANDORA_SOLR_QUERY_FACET_LUCENE_ESCAPE_REGEX_DEFAULT = '/(\+|-|&&|\|\||!|\(|\)|\{|\}|\[|\]|\^|~|\*|\?|\:|\"|\\)/';
+const ISLANDORA_SOLR_QUERY_FACET_LUCENE_ESCAPE_REGEX_DEFAULT = '/(\+|-|&&|\|\||!|\(|\)|\{|\}|\[|\]|\^|~|\*|\?|\:|\"|\\\)/';
 
 const ISLANDORA_SOLR_FACET_BUCKET_CLASSES_HOOK_BASE = 'islandora_solr_facet_bucket_classes';
 


### PR DESCRIPTION
**JIRA Ticket**: ISLANDORA-1889 (https://jira.duraspace.org/browse/ISLANDORA-1889)

# What does this Pull Request do?
Updated the default ISLANDORA_SOLR_QUERY_FACET_LUCENE_ESCAPE_REGEX_DEFAULT value to properly escape backslashes.

# What's new?
Updated the default Lucene escape regex to properly include the escaped backslash.

# How should this be tested?
Try searching for an object with a '\', such as '\title' (with out the quotes).

Recreate the issue this corrects by searching for a term as described in the test case above.


# Additional Notes:
This work is to supply a bug fix/patch to the code pull 301 introduced.

# Interested parties
@DiegoPino, @whikloj , @Islandora/7-x-1-x-committers
