### PR TITLE
Address ISLANDORA-1779.

### DIFF
--- a/includes/collection_sort.form.inc
+++ b/includes/collection_sort.form.inc
@@ -29,7 +29,7 @@ function islandora_solr_manage_collection_sort_form(array $form, array &$form_st
     'collection_sort_string' => array(
       '#type' => 'textfield',
       '#title' => t('Solr Collection Sort String'),
-      '#description' => t('One or more non-multivalued Solr fields to sort by when using the Solr collection query backend (by convention, multivalued fields have names that contain "_m" plus another letter at the end of their Solr names). Default sort order is " asc"; add " desc" to fields that should sort in descending order. If this field is empty, this collection will to fall back to the global sort settings in the order listed below.</br>Global Collection Sort: %collection_sort</br>Global Base Sort: %base_sort</br>', array(
+      '#description' => t('One or more non-multivalued Solr fields to sort by when using the Solr collection query backend (by convention, multivalued fields have names that contain "_m" plus another letter at the end of their Solr names). Add " asc" or " desc" to each fieldname. If this setting is empty, this collection will to fall back to the global sort settings in the order listed below.</br>Global Collection Sort: %collection_sort</br>Global Base Sort: %base_sort</br>', array(
         '%collection_sort' => empty($collection_sort) ? t("Not set") : $collection_sort,
         '%base_sort' => empty($base_sort) ? t("Not set") : $base_sort,
       )),

--- a/includes/collection_sort.form.inc
+++ b/includes/collection_sort.form.inc
@@ -29,7 +29,7 @@ function islandora_solr_manage_collection_sort_form(array $form, array &$form_st
     'collection_sort_string' => array(
       '#type' => 'textfield',
       '#title' => t('Solr Collection Sort String'),
-      '#description' => t('One or more non-multivalued Solr fields to sort by when using the Solr collection query backend. If set to empty, this collection will to fall back to the global sort settings in the order listed below.</br>Global Collection Sort: %collection_sort</br>Global Base Sort: %base_sort</br>', array(
+      '#description' => t('One or more non-multivalued Solr fields to sort by when using the Solr collection query backend (by convention, multivalued fields have names that contain "_m" plus another letter at the end of their Solr names). Default sort order is " asc"; add " desc" to fields that should sort in descending order. If this field is empty, this collection will to fall back to the global sort settings in the order listed below.</br>Global Collection Sort: %collection_sort</br>Global Base Sort: %base_sort</br>', array(
         '%collection_sort' => empty($collection_sort) ? t("Not set") : $collection_sort,
         '%base_sort' => empty($base_sort) ? t("Not set") : $base_sort,
       )),

--- a/includes/db.inc
+++ b/includes/db.inc
@@ -288,7 +288,6 @@ function islandora_solr_get_collection_sort_string($pid, $use_fallbacks = FALSE)
       ->fetchField();
 
     if (is_string($query)) {
-      $query = islandora_solr_set_default_collection_sort_order($query);
       return $query;
     }
   }
@@ -297,35 +296,15 @@ function islandora_solr_get_collection_sort_string($pid, $use_fallbacks = FALSE)
   if ($use_fallbacks) {
     $sort = variable_get('islandora_solr_collection_sort', '');
     if (!empty($sort)) {
-      $sort = islandora_solr_set_default_collection_sort_order($sort);
       return $sort;
     }
     $sort = variable_get('islandora_solr_base_sort', '');
     if (!empty($sort)) {
-      $sort = islandora_solr_set_default_collection_sort_order($sort);
       return $sort;
     }
   }
   // If all else fails, just don't set it at all.
   return NULL;
-}
-
-/**
- * Sets a default of ' asc' if no sort order string is provided.
- *
- * @param string $sort_setting
- *   The sort setting value to apply the default to.
- */
-function islandora_solr_set_default_collection_sort_order($sort_setting) {
-  $exploded_sort_setting = explode(',', $sort_setting);
-  foreach ($exploded_sort_setting as &$field) {
-    $field = trim($field);
-    if (!preg_match('/\s+(asc|desc)$/', $field)) {
-      $field = $field . ' asc';
-    }
-  }
-  $output = implode(',', $exploded_sort_setting);
-  return $output;
 }
 
 /**

--- a/includes/db.inc
+++ b/includes/db.inc
@@ -288,6 +288,7 @@ function islandora_solr_get_collection_sort_string($pid, $use_fallbacks = FALSE)
       ->fetchField();
 
     if (is_string($query)) {
+      $query = islandora_solr_set_default_collection_sort_order($query);
       return $query;
     }
   }
@@ -296,15 +297,35 @@ function islandora_solr_get_collection_sort_string($pid, $use_fallbacks = FALSE)
   if ($use_fallbacks) {
     $sort = variable_get('islandora_solr_collection_sort', '');
     if (!empty($sort)) {
+      $sort = islandora_solr_set_default_collection_sort_order($sort);
       return $sort;
     }
     $sort = variable_get('islandora_solr_base_sort', '');
     if (!empty($sort)) {
+      $sort = islandora_solr_set_default_collection_sort_order($sort);
       return $sort;
     }
   }
   // If all else fails, just don't set it at all.
   return NULL;
+}
+
+/**
+ * Sets a default of ' asc' if no sort order string is provided.
+ *
+ * @param string $sort_setting
+ *   The sort setting value to apply the default to.
+ */
+function islandora_solr_set_default_collection_sort_order($sort_setting) {
+  $exploded_sort_setting = explode(',', $sort_setting);
+  foreach ($exploded_sort_setting as &$field) {
+    $field = trim($field);
+    if (!preg_match('/\s+(asc|desc)$/', $field)) {
+      $field = $field . ' asc';
+    }
+  }
+  $output = implode(',', $exploded_sort_setting);
+  return $output;
 }
 
 /**

--- a/islandora_solr.module
+++ b/islandora_solr.module
@@ -542,7 +542,7 @@ function islandora_solr_form_islandora_basic_collection_admin_alter(&$form, &$fo
     '#type' => 'textfield',
     '#title' => t('Sort field for collection query'),
     '#size' => 100,
-    '#description' => t('Indicates an alternate default method for sorting collection members when using the Solr query backend. If unset, the Solr default query sort will be used.'),
+    '#description' => t('One or more non-multivalued Solr fields to sort by when using the Solr collection query backend (by convention, multivalued fields have names that contain "_m" plus another letter at the end of their Solr names). Default sort order is " asc"; add " desc" to fields that should sort in descending order. If this field is empty, the Solr default query sort will be used.'),
     '#default_value' => variable_get('islandora_solr_collection_sort', ''),
     '#states' => $states,
   );

--- a/islandora_solr.module
+++ b/islandora_solr.module
@@ -542,7 +542,7 @@ function islandora_solr_form_islandora_basic_collection_admin_alter(&$form, &$fo
     '#type' => 'textfield',
     '#title' => t('Sort field for collection query'),
     '#size' => 100,
-    '#description' => t('One or more non-multivalued Solr fields to sort by when using the Solr collection query backend (by convention, multivalued fields have names that contain "_m" plus another letter at the end of their Solr names). Default sort order is " asc"; add " desc" to fields that should sort in descending order. If this field is empty, the Solr default query sort will be used.'),
+    '#description' => t('One or more non-multivalued Solr fields to sort by when using the Solr collection query backend (by convention, multivalued fields have names that contain "_m" plus another letter at the end of their Solr names). Add " asc" or " desc" after each fieldname. If this setting is empty, the Solr default query sort will be used.'),
     '#default_value' => variable_get('islandora_solr_collection_sort', ''),
     '#states' => $states,
   );


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1779

# What does this Pull Request do?

Clarifies help text beneath config fields where "Sort field for collection query" and "Solr Collection Sort String" options are set,

# What's new?

* Changes to help text beneath the admin options form fields that define the Solr sort field for collection displays.
  * Explains how to identify a multivalued Solr field.
  * Indicates that you need to add " asc" or " desc" to each fieldname.

# How should this be tested?

## For global collection sort settings
* Check out the 7.x branch.
* Go to Islandora > Solution pack configuation > Collection Solution Pack. Under "Display Generation", choose "Solr" and select "Allow individual sort strings per-collection" so we can test at the collection level.
  * Read the help text beneath the "Sort field for collection query" field.
* Check out the 7.x-ISLANDORA-1779 branch.
  * Refresh the form page.
  * Reread the help text beneath the "Sort field for collection query" field.

## For collection-level sort settings
* Check out the 7.x branch.
* Go to a collection object, go to Manage > Collection > Set Solr Sort String
  * Read the help text beneath the "Solr Collection Sort String" field.
* Check out the 7.x-ISLANDORA-1779 branch.
  * Refresh the form page.
  * Reread the help text beneath the "Solr Collection Sort String" field.


# Additional Notes:

* Does this change require documentation to be updated? 
  * No
* Does this change add any new dependencies? 
  * No
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? 
  * No
* Could this change impact execution of existing code?
  * No

# Interested parties

@nhart as Islandora Solr Search component manager; @Islandora/7-x-1-x-committers
