### PR TITLE
add comma for multi-value fields

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -399,7 +399,7 @@ function islandora_solr_prepare_solr_results($solr_results) {
           $value = array_map($map_to_link, (array) $original_value, (array) $value);
         }
         elseif (in_array($field, $link_to_object)) {
-          $value = l(implode($value), $object_result['object_url'], $options);
+          $value = l(implode(", ", $value), $object_result['object_url'], $options);
         }
       }
       // Implode.

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -399,7 +399,7 @@ function islandora_solr_prepare_solr_results($solr_results) {
           $value = array_map($map_to_link, (array) $original_value, (array) $value);
         }
         elseif (in_array($field, $link_to_object)) {
-          $value = l(implode(", ", $value), $object_result['object_url'], $options);
+          $value = l(implode($separator, $value), $object_result['object_url'], $options);
         }
       }
       // Implode.


### PR DESCRIPTION
**JIRA Ticket**: (link)

https://jira.duraspace.org/browse/ISLANDORA-1914

* Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)

# What does this Pull Request do?

Fixes issue where Solr search results that use a multi-field property and are linked are not properly separated - for example multiple title fields.

A brief description of what the intended result of the PR will be and/or what problem it solves.

Adds a comma separator between each value.

# What's new?

Changes the displayed text so that a comma separator is added between each field

# How should this be tested?

* Set up Islandora to use Solr search
* Add the metadata field as one of the fields to be displayed on search 
* Create metadata record with multiple titles
* Set the field to link back to the object
* Search for record with multiple titles
* Ensure that both titles are displayed and a comma separator is used to separate both fields

@Islandora/7-x-1-x-committers
