### PR TITLE
Address 7.x-ISLANDORA-1749; fix field linking with sepcial characters…

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -388,9 +388,19 @@ function islandora_solr_prepare_solr_results($solr_results) {
         // Add link to search.
         if (in_array($field, $link_to_search)) {
           $map_to_link = function ($original_value, $formatted_value) use ($field) {
-            $solr_query = format_string('!field:"!value"', array(
+
+          if (variable_get('islandora_solr_advanced_search_block_lucene_syntax_escape', FALSE)) {
+            $lucene_regex = variable_get('islandora_solr_advanced_search_block_lucene_regex_default', ISLANDORA_SOLR_QUERY_FACET_LUCENE_ESCAPE_REGEX_DEFAULT);
+            $linked_value = islandora_solr_facet_query_escape(stripcslashes($original_value), $lucene_regex);
+          }
+          else {
+            $linked_value = islandora_solr_lesser_escape($original_value);
+          }
+          $linked_value = islandora_solr_replace_slashes($linked_value);
+
+          $solr_query = format_string('!field:"!value"', array(
               '!field' => $field,
-              '!value' => islandora_solr_lesser_escape($original_value),
+              '!value' => $linked_value,
             ));
             return l($formatted_value, "islandora/search/$solr_query", array(
               'html' => TRUE,

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -388,20 +388,19 @@ function islandora_solr_prepare_solr_results($solr_results) {
         // Add link to search.
         if (in_array($field, $link_to_search)) {
           $map_to_link = function ($original_value, $formatted_value) use ($field) {
+            if (variable_get('islandora_solr_advanced_search_block_lucene_syntax_escape', FALSE)) {
+              $lucene_regex = variable_get('islandora_solr_advanced_search_block_lucene_regex_default', ISLANDORA_SOLR_QUERY_FACET_LUCENE_ESCAPE_REGEX_DEFAULT);
+              $linked_value = islandora_solr_facet_query_escape(stripcslashes($original_value), $lucene_regex);
+            }
+            else {
+              $linked_value = islandora_solr_lesser_escape($original_value);
+            }
+            $linked_value = islandora_solr_replace_slashes($linked_value);
 
-          if (variable_get('islandora_solr_advanced_search_block_lucene_syntax_escape', FALSE)) {
-            $lucene_regex = variable_get('islandora_solr_advanced_search_block_lucene_regex_default', ISLANDORA_SOLR_QUERY_FACET_LUCENE_ESCAPE_REGEX_DEFAULT);
-            $linked_value = islandora_solr_facet_query_escape(stripcslashes($original_value), $lucene_regex);
-          }
-          else {
-            $linked_value = islandora_solr_lesser_escape($original_value);
-          }
-          $linked_value = islandora_solr_replace_slashes($linked_value);
-
-          $solr_query = format_string('!field:"!value"', array(
-              '!field' => $field,
-              '!value' => $linked_value,
-            ));
+            $solr_query = format_string('!field:"!value"', array(
+                '!field' => $field,
+                '!value' => $linked_value,
+              ));
             return l($formatted_value, "islandora/search/$solr_query", array(
               'html' => TRUE,
             ));


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1749

# What does this Pull Request do?
Allows linked terms containing special characters to search properly

# What's new?
Escapes special characters based on advanced search regex and replaces forward slashes with ~slsh~

# How should this be tested?
- enable "Escape Lucene special characters" with default regex under http://site.com/admin/islandora/search/islandora_solr/settings > Advanced search block
- enable "link to search" for a particular Solr field containing special characters under http://site.com/admin/islandora/search/islandora_solr/settings > Display fields

- Search for a particular object with said field containing special characters
Clicking on a linked term should perform a proper search and not return a 400 error.



# Additional Notes:
* Does this change require documentation to be updated? possibly?
* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? No

# Interested parties
@Islandora/7-x-1-x-committers @DiegoPino
