### PR TITLE
One stripslashes() too many, and some misplaced.

### DIFF
--- a/includes/blocks.inc
+++ b/includes/blocks.inc
@@ -587,7 +587,7 @@ function islandora_solr_advanced_search_form($form, &$form_state) {
       '#type' => 'textfield',
       '#size' => 20,
       '#default_value' => (isset($value['search']) ?
-        stripslashes($value['search']) :
+        $value['search'] :
         ''),
     );
     // Used for when the user presses enter on the search field.

--- a/includes/blocks.inc
+++ b/includes/blocks.inc
@@ -538,13 +538,13 @@ function islandora_solr_advanced_search_form($form, &$form_state) {
         $value = str_replace(array('(', ')'), '', $value);
 
         if (isset($values['terms'][$i]['search'])) {
-          $values['terms'][$i]['search'] = stripslashes($values['terms'][$i]['search']);
+          $values['terms'][$i]['search'] = $values['terms'][$i]['search'];
           // Append to search string.
-          $values['terms'][$i]['search'] .= ' ' . $value;
+          $values['terms'][$i]['search'] .= ' ' . stripslashes($value);
         }
         else {
           // Search field is not set, so create new search value.
-          $values['terms'][$i]['search'] = $value;
+          $values['terms'][$i]['search'] = stripslashes($value);
         }
       }
       // If it matches AND/OR/NOT, then we have the boolean operator.

--- a/islandora_solr.module
+++ b/islandora_solr.module
@@ -9,7 +9,7 @@ define('ISLANDORA_SOLR_SEARCH_PATH', 'islandora/search');
 define('ISLANDORA_SOLR_QUERY_SPLIT_REGEX', '/(?<!\\\\) /');
 define('ISLANDORA_SOLR_QUERY_FIELD_VALUE_SPLIT_REGEX', '/(?<!\\\\):/');
 
-const ISLANDORA_SOLR_QUERY_FACET_LUCENE_ESCAPE_REGEX_DEFAULT = '/(\+|-|&&|\|\||!|\(|\)|\{|\}|\[|\]|\^|~|\*|\?|\:|\"|\\\\)/';
+const ISLANDORA_SOLR_QUERY_FACET_LUCENE_ESCAPE_REGEX_DEFAULT = '/(\+|-|&&|\|\||!|\(|\)|\{|\}|\[|\]|\^|~|\*|\?|\:|\"|\\\\|\\/)/';
 
 const ISLANDORA_SOLR_FACET_BUCKET_CLASSES_HOOK_BASE = 'islandora_solr_facet_bucket_classes';
 

--- a/islandora_solr.module
+++ b/islandora_solr.module
@@ -9,7 +9,7 @@ define('ISLANDORA_SOLR_SEARCH_PATH', 'islandora/search');
 define('ISLANDORA_SOLR_QUERY_SPLIT_REGEX', '/(?<!\\\\) /');
 define('ISLANDORA_SOLR_QUERY_FIELD_VALUE_SPLIT_REGEX', '/(?<!\\\\):/');
 
-const ISLANDORA_SOLR_QUERY_FACET_LUCENE_ESCAPE_REGEX_DEFAULT = '/(\+|-|&&|\|\||!|\(|\)|\{|\}|\[|\]|\^|~|\*|\?|\:|"|\\\\|\\/)/';
+const ISLANDORA_SOLR_QUERY_FACET_LUCENE_ESCAPE_REGEX_DEFAULT = '/(\+|-|&&|\|\||!|\(|\)|\{|\}|\[|\]|\^| |~|\*|\?|\:|"|\\\\|\\/)/';
 
 const ISLANDORA_SOLR_FACET_BUCKET_CLASSES_HOOK_BASE = 'islandora_solr_facet_bucket_classes';
 

--- a/islandora_solr.module
+++ b/islandora_solr.module
@@ -9,7 +9,7 @@ define('ISLANDORA_SOLR_SEARCH_PATH', 'islandora/search');
 define('ISLANDORA_SOLR_QUERY_SPLIT_REGEX', '/(?<!\\\\) /');
 define('ISLANDORA_SOLR_QUERY_FIELD_VALUE_SPLIT_REGEX', '/(?<!\\\\):/');
 
-const ISLANDORA_SOLR_QUERY_FACET_LUCENE_ESCAPE_REGEX_DEFAULT = '/(\+|-|&&|\|\||!|\(|\)|\{|\}|\[|\]|\^|~|\*|\?|\:|\"|\\\\|\\/)/';
+const ISLANDORA_SOLR_QUERY_FACET_LUCENE_ESCAPE_REGEX_DEFAULT = '/(\+|-|&&|\|\||!|\(|\)|\{|\}|\[|\]|\^|~|\*|\?|\:|"|\\\\|\\/)/';
 
 const ISLANDORA_SOLR_FACET_BUCKET_CLASSES_HOOK_BASE = 'islandora_solr_facet_bucket_classes';
 


### PR DESCRIPTION
**JIRA Ticket**: [ISLANDORA-1889](https://jira.duraspace.org/browse/ISLANDORA-1889)

Supercedes #311.

# What does this Pull Request do?

Make display of query input consistent.

# What's new?

1. Removal of a `stripslashes()` invocation.
2. Addition of forward slash to be escaped to support newer Solr versions.
3. Fix use of `stripslashes()` in advanced searches with multiple terms.

# How should this be tested?

1. Ingest objects with a variety of forward and backslashes and spaces in their titles.
2. [Configure](https://github.com/Islandora/islandora_solr_facet_pages/pull/32#issuecomment-283071291) to use the new regex escape functionality. 
3. Perform simple and advanced searches for these objects using the exact titles.

# Interested parties

@DiegoPino @MorganDawe @willtp87 