### PR TITLE
query breadcrumbs with collection breadcrumbs

### DIFF
--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -1088,6 +1088,12 @@ function islandora_solr_admin_breadcrumbs_settings(array $form, array &$form_sta
     one per line. Will search top to bottom and stop on the first hit.'),
     '#default_value' => variable_get('islandora_solr_breadcrumbs_parent_fields', "RELS_EXT_isMemberOfCollection_uri_ms\r\nRELS_EXT_isMemberOf_uri_ms"),
   );
+  $form['islandora_solr_breadcrumbs_admin']['islandora_solr_breadcrumbs_add_collection_query'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Append query breadcrumbs to collection breadcrumbs'),
+    '#description' => t('Appends any additional available breadcrumbs, such as facet breadcrumbs, to the standard collection hierarchy breadcrumbs.'),
+    '#default_value' => variable_get('islandora_solr_breadcrumbs_add_collection_query', FALSE),
+  );
   return system_settings_form($form);
 }
 

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -1091,7 +1091,7 @@ function islandora_solr_admin_breadcrumbs_settings(array $form, array &$form_sta
   $form['islandora_solr_breadcrumbs_admin']['islandora_solr_breadcrumbs_add_collection_query'] = array(
     '#type' => 'checkbox',
     '#title' => t('Append query breadcrumbs to collection breadcrumbs'),
-    '#description' => t('Appends any additional available breadcrumbs, such as facet breadcrumbs, to the standard collection hierarchy breadcrumbs.'),
+    '#description' => t('Appends any additional available breadcrumbs, such as facet breadcrumbs, to the standard collection hierarchy breadcrumbs, if using the Solr collection query backend.'),
     '#default_value' => variable_get('islandora_solr_breadcrumbs_add_collection_query', FALSE),
   );
   return system_settings_form($form);

--- a/includes/breadcrumbs.inc
+++ b/includes/breadcrumbs.inc
@@ -11,7 +11,8 @@ function islandora_solr_islandora_breadcrumbs_backends_callable($object) {
   $breadcrumbs = islandora_solr_get_breadcrumbs_recursive($object->id);
   // Pop off the current object.
   array_pop($breadcrumbs);
-  if (variable_get('islandora_solr_breadcrumbs_add_collection_query', FALSE)) {
+  $query_backend = variable_get('islandora_basic_collection_display_backend', 'islandora_basic_collection_legacy_sparql');
+  if (variable_get('islandora_solr_breadcrumbs_add_collection_query', FALSE) && $query_backend == 'islandora_solr_query_backend') {
     global $_islandora_solr_queryclass;
     if (isset($_islandora_solr_queryclass)) {
       $results = new IslandoraSolrResults();

--- a/includes/breadcrumbs.inc
+++ b/includes/breadcrumbs.inc
@@ -17,10 +17,9 @@ function islandora_solr_islandora_breadcrumbs_backends_callable($object) {
     if (isset($_islandora_solr_queryclass)) {
       $results = new IslandoraSolrResults();
       $qp_breadcrumbs = $results->getBreadcrumbs($_islandora_solr_queryclass);
-      // Shift off 'Home' and the breadcrumb query predicate.
-      array_shift($qp_breadcrumbs);
-      array_shift($qp_breadcrumbs);
-      return array_merge($breadcrumbs, $qp_breadcrumbs);
+      // Slice out the first two breadcrumbs, as they are 'Home' and the
+      // breadcrumb query predicate.
+      return array_merge($breadcrumbs, array_slice($qp_breadcrumbs, 2));
     }
   }
   return $breadcrumbs;

--- a/includes/breadcrumbs.inc
+++ b/includes/breadcrumbs.inc
@@ -11,6 +11,17 @@ function islandora_solr_islandora_breadcrumbs_backends_callable($object) {
   $breadcrumbs = islandora_solr_get_breadcrumbs_recursive($object->id);
   // Pop off the current object.
   array_pop($breadcrumbs);
+  if (variable_get('islandora_solr_breadcrumbs_add_collection_query', FALSE)) {
+    global $_islandora_solr_queryclass;
+    if (isset($_islandora_solr_queryclass)) {
+      $results = new IslandoraSolrResults();
+      $qp_breadcrumbs = $results->getBreadcrumbs($_islandora_solr_queryclass);
+      // Shift off 'Home' and the breadcrumb query predicate.
+      array_shift($qp_breadcrumbs);
+      array_shift($qp_breadcrumbs);
+      return array_merge($breadcrumbs, $qp_breadcrumbs);
+    }
+  }
   return $breadcrumbs;
 }
 

--- a/includes/results.inc
+++ b/includes/results.inc
@@ -320,14 +320,29 @@ class IslandoraSolrResults {
   /**
    * Sets the Drupal breadcrumbs.
    *
-   * Sets the Drupal breadcrumbs based on the current query and filters.
+   * @param IslandoraSolrQueryProcessor $islandora_solr_query
+   *   The IslandoraSolrQueryProcessor object, which includes the current query
+   *   settings and the raw Solr results.
+   */
+  public function setBreadcrumbs($islandora_solr_query) {
+    $breadcrumb = $this->getBreadcrumbs();
+    drupal_set_breadcrumb($breadcrumb);
+  }
+
+  /**
+   * Gets the Drupal breadcrumbs.
+   *
+   * Gets the Drupal breadcrumbs based on the current query and filters.
    * Provides links to exclude the query or filters.
    *
    * @param IslandoraSolrQueryProcessor $islandora_solr_query
    *   The IslandoraSolrQueryProcessor object which includes the current query
    *   settings and the raw Solr results.
+   *
+   * @return array
+   *   An array of breadcrumbs.
    */
-  public function setBreadcrumbs($islandora_solr_query) {
+  public function getBreadcrumbs($islandora_solr_query) {
     // $_GET['q'] didn't seem to work here.
     $path = current_path();
     // Get date format.
@@ -474,7 +489,7 @@ class IslandoraSolrResults {
     }
     $context = 'solr';
     drupal_alter('islandora_breadcrumbs', $breadcrumb, $context);
-    drupal_set_breadcrumb($breadcrumb);
+    return $breadcrumb;
   }
 
   /**

--- a/includes/results.inc
+++ b/includes/results.inc
@@ -325,7 +325,7 @@ class IslandoraSolrResults {
    *   settings and the raw Solr results.
    */
   public function setBreadcrumbs($islandora_solr_query) {
-    $breadcrumb = $this->getBreadcrumbs();
+    $breadcrumb = $this->getBreadcrumbs($islandora_solr_query);
     drupal_set_breadcrumb($breadcrumb);
   }
 

--- a/islandora_solr.install
+++ b/islandora_solr.install
@@ -60,6 +60,8 @@ function islandora_solr_uninstall() {
     'islandora_solr_search_field_value_separator',
     'islandora_solr_search_truncated_field_value_separator',
     'islandora_solr_collection_result_limit_block_override',
+    'islandora_solr_breadcrumbs_parent_fields',
+    'islandora_solr_breadcrumbs_add_collection_query',
   ));
   array_walk($variables, 'variable_del');
 }
@@ -328,7 +330,6 @@ function islandora_solr_search_settings_variables() {
     'islandora_solr_primary_display',
     'islandora_solr_request_handler',
     'islandora_solr_luke_timeout',
-    'islandora_solr_breadcrumbs_parent_fields',
   );
   return $variables;
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1942

# What does this Pull Request do?

Makes it possible to add query breadcrumbs to the collection breadcrumbs when using Solr to generate collection breadcrumbs.

# What's new?
* An option to append query breadcrumbs to collection breadcrumbs has been added to the admin form at admin/islandora/search/islandora_solr/breadcrumbs
* `IslandoraSolrResults::setBreadcrumbs()` has been split into `setBreadcrumbs()` and `getBreadcrumbs()`. `setBreadcrumbs()` functions precisely the same, and no existing code should be affected.

# How should this be tested?
* Switch to the Solr collection query backend at admin/islandora/solution_pack_config/basic_collection
* Check off 'Append query breadcrumbs to collection breadcrumbs' at admin/islandora/search/islandora_solr/breadcrumbs
* Enable the 'Islandora Solr Facets' block
* Configure faceting in Solr so that it will return results when viewing items in a collection
* Navigate to the collection and apply a facet. It should show up in the breadcrumbs.
* Click the 'x' next to the facet. The facet should be removed.
* These extra breadcrumbs should not show up if 'Append query breadcrumbs to collection breadcrumbs' is not checked, or if the Solr collection query backend is not 'Solr'.

# Interested parties
@nhart is the maintainer of this module; not sure who else would be interested but as he can't merge this, pinging the rest of @Islandora/7-x-1-x-committers 
