### PR TITLE
Islandora 1743 -- Label for simple search

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Set the 'Solr URL' and select a 'Request handler' in Administration » Islandora
 
 Islandora Solr Search offers many more configuration options in Administration » Islandora » Solr Index » Solr settings (admin/islandora/search/islandora_solr/settings).
 
+Configuration of the labels attached to the Islandora Simple Search can be done via the block's configuration settings.
+
 Islandora Solr Search also implements the Islandora Basic Collection solution pack's query backend to drive the collection display using Solr instead of SPARQL/Fedora. This functionality can be applied on the collection solution pack's configuration page (admin/islandora/solution_pack_config/basic_collection), and that same page provides settings for sorting the Solr collection view globally and per-collection. The query backend relies on the relationship fields in the "Required Solr Fields" section of the Solr settings; the fields in that section should be confirmed before using Solr to drive the display.
 
 ### Breadcrumbs

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -489,32 +489,6 @@ function islandora_solr_admin_settings($form, &$form_state) {
     '#default_value' => variable_get('islandora_solr_facet_max_limit', '20'),
   );
 
-  // Simple search block.
-  $form['islandora_solr_tabs']['simple_search_block'] = array(
-    '#type' => 'fieldset',
-    '#title' => t('Simple search block'),
-    '#collapsible' => TRUE,
-    '#collapsed' => TRUE,
-  );
-
-  // Simple search block -- Specify label.
-  $form['islandora_solr_tabs']['simple_search_block']['islandora_solr_simple_search_label_title'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Simple Search Label'),
-    '#size' => 30,
-    '#default_value' => variable_get('islandora_solr_simple_search_label_title', 'Search Term'),
-    '#description' => t('Customize label text associated with search input form. Accessibility guidelines recommend whenever possible to explicitly associate label text with form inputs.'),
-    '#required' => TRUE,
-  );
-
-  // Simple search block -- hide label.
-  $form['islandora_solr_tabs']['simple_search_block']['islandora_solr_simple_search_label_visibility'] = array(
-    '#type' => 'checkbox',
-    '#title' => t('Simple Search Label Visibility'),
-    '#default_value' => variable_get('islandora_solr_simple_search_label_visibility', TRUE),
-    '#description' => t('Display the label alongside the simple search input. If unchecked, label will be visibly hidden but will be kept available for screen-readers.'),
-  );
-
   // Advanced search block.
   $form['islandora_solr_tabs']['advanced_search_block'] = array(
     '#type' => 'fieldset',

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -490,14 +490,14 @@ function islandora_solr_admin_settings($form, &$form_state) {
   );
 
   // Simple search block.
-  $form['islandora_solr_tabs']['simple_search_block'] = array (
+  $form['islandora_solr_tabs']['simple_search_block'] = array(
     '#type' => 'fieldset',
     '#title' => t('Simple search block'),
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
   );
 
-  // Simple search block -- Specify label
+  // Simple search block -- Specify label.
   $form['islandora_solr_tabs']['simple_search_block']['islandora_solr_simple_search_label_title'] = array(
     '#type' => 'textfield',
     '#title' => t('Simple Search Label'),
@@ -507,7 +507,7 @@ function islandora_solr_admin_settings($form, &$form_state) {
     '#required' => TRUE,
   );
 
-  // Simple search block -- hide label
+  // Simple search block -- hide label.
   $form['islandora_solr_tabs']['simple_search_block']['islandora_solr_simple_search_label_visibility'] = array(
     '#type' => 'checkbox',
     '#title' => t('Simple Search Label Visibility'),

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -497,6 +497,16 @@ function islandora_solr_admin_settings($form, &$form_state) {
     '#collapsed' => TRUE,
   );
 
+  // Simple search block -- Specify label
+  $form['islandora_solr_tabs']['simple_search_block']['islandora_solr_simple_search_label_title'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Simple Search Label'),
+    '#size' => 30,
+    '#default_value' => variable_get('islandora_solr_simple_search_label_title', 'Search Term'),
+    '#description' => t('Customize label text associated with search input form. Accessibility guidelines recommend whenever possible to explicitly associate label text with form inputs.'),
+    '#required' => TRUE,
+  );
+
   // Simple search block -- hide label
   $form['islandora_solr_tabs']['simple_search_block']['islandora_solr_simple_search_label_visibility'] = array(
     '#type' => 'checkbox',

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -489,6 +489,22 @@ function islandora_solr_admin_settings($form, &$form_state) {
     '#default_value' => variable_get('islandora_solr_facet_max_limit', '20'),
   );
 
+  // Simple search block.
+  $form['islandora_solr_tabs']['simple_search_block'] = array (
+    '#type' => 'fieldset',
+    '#title' => t('Simple search block'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+
+  // Simple search block -- hide label
+  $form['islandora_solr_tabs']['simple_search_block']['islandora_solr_simple_search_label_visibility'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Simple Search Label Visibility'),
+    '#default_value' => variable_get('islandora_solr_simple_search_label_visibility', TRUE),
+    '#description' => t('Display the label alongside the simple search input. If unchecked, label will be visibly hidden but will be kept available for screen-readers.'),
+  );
+
   // Advanced search block.
   $form['islandora_solr_tabs']['advanced_search_block'] = array(
     '#type' => 'fieldset',

--- a/includes/blocks.inc
+++ b/includes/blocks.inc
@@ -106,6 +106,40 @@ function islandora_solr_block_info() {
 }
 
 /**
+ * Implements hook_block_configure().
+ */
+function islandora_solr_block_configure($delta = '') {
+  if ($delta == 'simple') {
+    $form = array();
+    $form['islandora_solr_simple_search_label_title'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Simple Search Label'),
+      '#size' => 30,
+      '#default_value' => variable_get('islandora_solr_simple_search_label_title', 'Search Term'),
+      '#description' => t('Customize label text associated with search input form. Accessibility guidelines recommend whenever possible to explicitly associate label text with form inputs.'),
+      '#required' => TRUE,
+    );
+    $form['islandora_solr_simple_search_label_visibility'] = array (
+      '#type' => 'checkbox',
+      '#title' => t('Simple Search Label Visibility'),
+      '#default_value' => variable_get('islandora_solr_simple_search_label_visibility', TRUE),
+      '#description' => t('Display the label alongside the simple search input. If unchecked, label will be visibly hidden but will be kept available for screen-readers.'),
+    );
+    return $form;
+  }
+}
+
+/**
+ * Implements hook_block_save()
+ */
+function islandora_solr_block_save($delta = '', $edit = array()) {
+  if ($delta == 'simple') {
+    variable_set('islandora_solr_simple_search_label_title', $edit['islandora_solr_simple_search_label_title']);
+    variable_set('islandora_solr_simple_search_label_visibility', $edit['islandora_solr_simple_search_label_visibility']);
+  }
+}
+
+/**
  * Implements hook_form_FORM_ID_alter().
  *
  * Currently checks for delta of explore and modifies the form to add custom
@@ -428,7 +462,7 @@ function islandora_solr_simple_search_form($form, &$form_state) {
     ),
   );
 
-  if (variable_get('islandora_solr_simple_search_label_visibility', 'TRUE') == FALSE) {
+  if (variable_get('islandora_solr_simple_search_label_visibility', TRUE) == FALSE) {
     $title_visible = 'invisible';
   }
   else {

--- a/includes/blocks.inc
+++ b/includes/blocks.inc
@@ -119,7 +119,7 @@ function islandora_solr_block_configure($delta = '') {
       '#description' => t('Customize label text associated with search input form. Accessibility guidelines recommend whenever possible to explicitly associate label text with form inputs.'),
       '#required' => TRUE,
     );
-    $form['islandora_solr_simple_search_label_visibility'] = array (
+    $form['islandora_solr_simple_search_label_visibility'] = array(
       '#type' => 'checkbox',
       '#title' => t('Simple Search Label Visibility'),
       '#default_value' => variable_get('islandora_solr_simple_search_label_visibility', TRUE),
@@ -130,7 +130,7 @@ function islandora_solr_block_configure($delta = '') {
 }
 
 /**
- * Implements hook_block_save()
+ * Implements hook_block_save().
  */
 function islandora_solr_block_save($delta = '', $edit = array()) {
   if ($delta == 'simple') {

--- a/includes/blocks.inc
+++ b/includes/blocks.inc
@@ -428,14 +428,14 @@ function islandora_solr_simple_search_form($form, &$form_state) {
     ),
   );
 
-  if (variable_get('islandora_solr_simple_search_label_visibility') == FALSE) {
+  if (variable_get('islandora_solr_simple_search_label_visibility', 'TRUE') == FALSE) {
     $title_visible = 'invisible';
   }
   else {
     $title_visible = 'before';
   }
 
-  $title_label = variable_get('islandora_solr_simple_search_label_title');
+  $title_label = variable_get('islandora_solr_simple_search_label_title', 'Search Term');
 
   $form['simple']["islandora_simple_search_query"] = array(
     '#size' => '15',

--- a/includes/blocks.inc
+++ b/includes/blocks.inc
@@ -428,11 +428,11 @@ function islandora_solr_simple_search_form($form, &$form_state) {
     ),
   );
 
-  if (variable_get('islandora_solr_simple_search_label_visibility', FALSE)) {
+  if (variable_get('islandora_solr_simple_search_label_visibility') == FALSE) {
     $title_visible = 'invisible';
   }
   else {
-    $title_visible = '';
+    $title_visible = 'before';
   }
 
   $form['simple']["islandora_simple_search_query"] = array(

--- a/includes/blocks.inc
+++ b/includes/blocks.inc
@@ -427,10 +427,19 @@ function islandora_solr_simple_search_form($form, &$form_state) {
       ),
     ),
   );
+
+  if (variable_get('islandora_solr_simple_search_label_visibility', FALSE)) {
+    $title_visible = 'invisible';
+  }
+  else {
+    $title_visible = '';
+  }
+
   $form['simple']["islandora_simple_search_query"] = array(
     '#size' => '15',
     '#type' => 'textfield',
     '#title' => t("Search Term"),
+    '#title_display' => $title_visible,
     // @todo Should this be the searched value?
     '#default_value' => '',
   );
@@ -440,7 +449,6 @@ function islandora_solr_simple_search_form($form, &$form_state) {
   );
   return $form;
 }
-
 
 /**
  * Islandora Solr simple search form submit callback.

--- a/includes/blocks.inc
+++ b/includes/blocks.inc
@@ -440,7 +440,7 @@ function islandora_solr_simple_search_form($form, &$form_state) {
   $form['simple']["islandora_simple_search_query"] = array(
     '#size' => '15',
     '#type' => 'textfield',
-    '#title' => $title_label,
+    '#title' => check_plain($title_label),
     '#title_display' => $title_visible,
     // @todo Should this be the searched value?
     '#default_value' => '',

--- a/includes/blocks.inc
+++ b/includes/blocks.inc
@@ -435,10 +435,12 @@ function islandora_solr_simple_search_form($form, &$form_state) {
     $title_visible = 'before';
   }
 
+  $title_label = variable_get('islandora_solr_simple_search_label_title');
+
   $form['simple']["islandora_simple_search_query"] = array(
     '#size' => '15',
     '#type' => 'textfield',
-    '#title' => t("Search Term"),
+    '#title' => t($title_label),
     '#title_display' => $title_visible,
     // @todo Should this be the searched value?
     '#default_value' => '',

--- a/includes/blocks.inc
+++ b/includes/blocks.inc
@@ -440,7 +440,7 @@ function islandora_solr_simple_search_form($form, &$form_state) {
   $form['simple']["islandora_simple_search_query"] = array(
     '#size' => '15',
     '#type' => 'textfield',
-    '#title' => t($title_label),
+    '#title' => $title_label,
     '#title_display' => $title_visible,
     // @todo Should this be the searched value?
     '#default_value' => '',

--- a/islandora_solr.install
+++ b/islandora_solr.install
@@ -62,6 +62,8 @@ function islandora_solr_uninstall() {
     'islandora_solr_collection_result_limit_block_override',
     'islandora_solr_breadcrumbs_parent_fields',
     'islandora_solr_breadcrumbs_add_collection_query',
+    'islandora_solr_simple_search_label_visibility',
+    'islandora_solr_simple_search_label_title',
   ));
   array_walk($variables, 'variable_del');
 }


### PR DESCRIPTION
**JIRA Ticket**: [https://jira.duraspace.org/browse/ISLANDORA-1743](https://jira.duraspace.org/browse/ISLANDORA-1743)

* Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)

# What does this Pull Request do?

Addresses issue of a hardcoded label attached to the Simple Search input. Allows users to change label text and choose to visibly hide the label, while maintaining label availability for screen-readers, etc.

# What's new?
Introduces a new group of settings under Solr Settings for the Simple Search Block, constructs the input label using these settings.

<img width="1324" alt="screen shot 2017-05-26 at 15 58 37" src="https://cloud.githubusercontent.com/assets/19806604/26510936/9be7d08a-422d-11e7-8531-97235bc935e9.png">

# How should this be tested?

Once implemented, insure that label text and visibility respond to controls.

# Additional Notes:
Default settings are to use the same label text as currently hard-coded and defaults to visible.
Label text is required in order to meet accessibility guidelines.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/7-x-1-x-committers
Ping Maintainer Nelson Hart (@nhart)
Ping Melissa Anez (@manez) -- Interested party on JIRA ticket
