### PR TITLE
better labels for boolean facets

### DIFF
--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -1344,11 +1344,18 @@ function _islandora_solr_admin_settings_submit($form, &$form_state) {
               }
             }
             if (module_exists('i18n_string')) {
-              if (isset($solr_field_settings['label'])) {
-                i18n_string_update("islandora_solr:field_settings:$field_type:label:$solr_field", $solr_field_settings['label']);
-              }
-              else {
-                i18n_string_remove("islandora_solr:field_settings:$field_type:label:$solr_field");
+              $to_i18nize = array(
+                'label',
+                'boolean_facet_true_replacement',
+                'boolean_facet_false_replacement',
+              );
+              foreach ($to_i18nize as $string_type) {
+                if (isset($solr_field_settings[$string_type])) {
+                  i18n_string_update("islandora_solr:field_settings:$field_type:$string_type:$solr_field", $solr_field_settings[$string_type]);
+                }
+                else {
+                  i18n_string_remove("islandora_solr:field_settings:$field_type:$string_type:$solr_field");
+                }
               }
             }
             $insert_values[] = array(

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -1718,6 +1718,8 @@ function _islandora_solr_handle_solr_field_settings($solr_field_settings = NULL,
           'date_filter_datepicker_enabled',
           'date_filter_datepicker_range',
           'pid_object_label',
+          'boolean_facet_true_replacement',
+          'boolean_facet_false_replacement',
         ));
         $relevant_values = array_intersect_key($solr_field_settings, $fields);
         $relevant_values['label'] = isset($relevant_values['label']) ?
@@ -2181,6 +2183,31 @@ function islandora_solr_admin_settings_facet_fields($form, &$form_state, $variab
         'visible' => array(
           ':input[name="date_filter_datepicker_enabled"]' => array('checked' => TRUE),
         ),
+      ),
+    );
+  }
+  elseif (islandora_solr_is_boolean_field($solr_field)) {
+    // Defaults.
+    $values += array(
+      'boolean_facet_true_replacement' => '',
+      'boolean_facet_false_replacement' => '',
+    );
+    $form['options']['boolean_facet'] = array(
+      '#type' => 'fieldset',
+      '#title' => t('Boolean Facet Options'),
+      '#collapsible' => FALSE,
+      'blurb' => array(
+        '#markup' => t('Enter replacement values for the labels of TRUE and FALSE results for boolean facets. Leaving a field empty will cause that result to show up as "true" or "false", respectively, which may be less than clear to the end user.'),
+      ),
+      'boolean_facet_true_replacement' => array(
+        '#type' => 'textfield',
+        '#title' => t('Replacement for TRUE values'),
+        '#default_value' => $values['boolean_facet_true_replacement'],
+      ),
+      'boolean_facet_false_replacement' => array(
+        '#type' => 'textfield',
+        '#title' => t('Replacement for FALSE values'),
+        '#default_value' => $values['boolean_facet_false_replacement'],
       ),
     );
   }

--- a/includes/db.inc
+++ b/includes/db.inc
@@ -255,14 +255,22 @@ function islandora_solr_get_date_format_facets() {
  * Function used with optional i18n_string integration.
  */
 function islandora_solr_translate_field_labels(array &$records) {
+  $to_i18nize = array(
+    'label',
+    'boolean_facet_true_replacement',
+    'boolean_facet_false_replacement',
+  );
   foreach ($records as &$record) {
     $settings = &$record['solr_field_settings'];
-    if (isset($settings['label'])) {
-      $string_id = format_string("islandora_solr:field_settings:@type:label:@field", array(
-        '@type' => $record['field_type'],
-        '@field' => $record['solr_field'],
-      ));
-      $settings['label'] = i18n_string_translate($string_id, $settings['label']);
+    foreach ($to_i18nize as $string_type) {
+      if (isset($settings[$string_type])) {
+        $string_id = format_string("islandora_solr:field_settings:@type:@string:@field", array(
+          '@type' => $record['field_type'],
+          '@string' => $string_type,
+          '@field' => $record['solr_field'],
+        ));
+        $settings[$string_type] = i18n_string_translate($string_id, $settings[$string_type]);
+      }
     }
   }
 }

--- a/includes/results.inc
+++ b/includes/results.inc
@@ -968,6 +968,14 @@ class IslandoraSolrFacets {
         $bucket = ($label ? $label : $bucket);
       }
 
+      // Replace labels for boolean values if necessary.
+      if ($bucket == 'true' && isset($this->settings['solr_field_settings']['boolean_facet_true_replacement']) && !empty($this->settings['solr_field_settings']['boolean_facet_true_replacement'])) {
+        $bucket = $this->settings['solr_field_settings']['boolean_facet_true_replacement'];
+      }
+      if ($bucket == 'false' && isset($this->settings['solr_field_settings']['boolean_facet_false_replacement']) && !empty($this->settings['solr_field_settings']['boolean_facet_false_replacement'])) {
+        $bucket = $this->settings['solr_field_settings']['boolean_facet_false_replacement'];
+      }
+
       // Current URL query.
       $fq = isset($islandora_solr_query->solrParams['fq']) ? $islandora_solr_query->solrParams['fq'] : array();
       // 1: Check minimum count.

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -575,11 +575,42 @@ function islandora_solr_is_date_field($solr_field) {
     'org.apache.solr.schema.DateField',
     'org.apache.solr.schema.TrieDateField',
   );
+  return islandora_solr_is_typed_field($solr_field, $date_types);
+}
+
+/**
+ * Check the field type against boolean-type fields.
+ *
+ * @param string $solr_field
+ *   The Solr field name.
+ *
+ * @return bool
+ *   Whether the field is a boolean type.
+ */
+function islandora_solr_is_boolean_field($solr_field) {
+  $bool_types = array(
+    'org.apache.solr.schema.BoolField',
+  );
+  return islandora_solr_is_typed_field($solr_field, $bool_types);
+}
+
+/**
+ * Check the field type against an array of types.
+ *
+ * @param string $solr_field
+ *   The Solr field name.
+ * @param array $types
+ *   A list of Solr field type classes to check against.
+ *
+ * @return bool
+ *   Whether the field type is in the provided list.
+ */
+function islandora_solr_is_typed_field($solr_field, $types) {
   $luke_result = islandora_solr_get_luke(NULL, $solr_field);
   $type = (isset($luke_result['fields'][$solr_field]['type']) ? $luke_result['fields'][$solr_field]['type'] : FALSE);
   if ($type) {
     $class = islandora_solr_get_type_class($type);
-    return in_array($class, $date_types);
+    return in_array($class, $types);
   }
   return FALSE;
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2003

# What does this Pull Request do?
Adds configuration option to replace the labels of Solr boolean facets with more human-readable labels.

# What's new?
When configuring facets for boolean fields, a new fieldset appears allowing label values to be specified for 'true' and 'false' results.

With this, a new utility function has been created to determine whether a field is a Solr boolean.

# How should this be tested?
* Create a boolean field on a Solr doc.
* Add it to the Solr facet settings.
* It should show up in search results with either 'true', 'false', both, or neither results.
* Configure the boolean field; add a true value and a false value.
* In all three cases, you should see the values you entered in the configuration used as replacement values for the facet labels 'true' and 'false'.
* Faceting in all cases should still work as expected.

# Interested parties
@nhart is listed as the maintainer here, but this is a simple general configuration change that any of the @Islandora/7-x-1-x-committers can be involved in.
