### PR TITLE
return a string

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -558,6 +558,10 @@ function islandora_solr_truncate_field_display($display_values, $max_length, $ad
     $updated_display_values .= '</span>';
 
   }
+  else {
+    $updated_display_values = '';
+  }
+
   return $updated_display_values;
 };
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2006

# What does this Pull Request do?

Makes it so that `islandora_solr_truncate_field_display()` always returns a string instead of only returning a string if `$display_values` contains entries.

# What's new?
This came up as a result of trying to do whole-field truncation on an Islandora Solr Metadata display that may not necessarily have results. When this is the case, `islandora_solr_truncate_field_display()` takes the empty array and returns it instead of reformatting it into a string. It then tries to print the array, which breaks the display field.

This change adds an `else` in the case where the display field count is not `> 0` that ensures that a string is returned, albeit empty. The return string contains no markup, as the `<span>` statement for the truncated version is only required to facilitate the wrapper toggling.

# How should this be tested?
* Enable the Islandora Solr Metadata metadata display. Make sure in the Islandora Solr Metadata general confguration that  'Omit Empty Values' is not checked.
* Create an Islandora Solr Metadata display containing a field which may not have values.
* Set the field's Truncation Type to 'Limit Length of the whole field'; give it a Max Length greater than 0.
* Navigate to an object which doesn't implement this field.
* Explosions

# Additional Notes:
This change will break existing code relying on `islandora_solr_truncated_field_display()` returning an array. I cannot imagine that this is the case anywhere; the function claims to only return a string, so if anyone did that anywhere, well, tell e'm to read the docs I guess?

# Interested parties
@nhart maintains this, but this is a bug, so @Islandora/7-x-1-x-committers may wanna weigh in.