### PR TITLE
7.x filter html

### DIFF
--- a/includes/field_truncation.inc
+++ b/includes/field_truncation.inc
@@ -1,0 +1,157 @@
+<?php
+
+/**
+ * @file
+ * Class to assist in field truncation, paying special attention to HTML.
+ */
+
+/**
+ * Islandora Field Truncation.
+ */
+class IslandoraSolrFieldTruncation {
+  protected $writer;
+  protected $output = '';
+  protected $truncationLength;
+  protected $wordSafe;
+  protected $addEllipsis;
+  protected $wordsafeLength;
+
+  protected $generalDom = <<<EOXML
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+</head>
+<body>@replace@</body>
+</html>
+EOXML;
+
+  const XHTML_URI = 'http://www.w3.org/1999/xhtml';
+
+  /**
+   * Class Constructor function.
+   *
+   * @param string $text
+   *   The text to truncate.
+   * @param string $desired_length
+   *   The desired length to truncate to.
+   * @param bool $word_safe
+   *   Attempt to truncate on a word boundary.
+   * @param string $add_ellipsis
+   *   Add '...' to the end of the truncated string.
+   * @param int $wordsafe_length
+   *   If $word_safe is true, the minimum acceptable length for truncation.
+   *   No effect if $word_safe is false.
+   */
+  public function __construct($text, $desired_length, $word_safe = TRUE, $add_ellipsis = TRUE, $wordsafe_length = 1) {
+    $this->truncationLength = $desired_length;
+    $this->wordSafe = $word_safe;
+    $this->addEllipsis = $add_ellipsis;
+    $this->wordsafeLength = $wordsafe_length;
+
+    if (strpos($text, '<') === FALSE && strpos($text, '>') === FALSE) {
+      // No apparent markup... No need for more processing.
+      $this->output = $this->truncateText($text);
+      return;
+    }
+
+    $this->writer = new XMLWriter();
+    $this->writer->openMemory();
+    $this->process($this->document($text)->getElementsByTagName('body')->item(0), $this->truncationLength);
+    $this->output = $this->writer->outputMemory();
+  }
+
+  /**
+   * Helper; load up text into a DOMDocument.
+   *
+   * Adapted from filter_load_dom(), but made to do XML instead of HTML.
+   *
+   * @param string $text
+   *   A string which may or may not contain markup elements.
+   *
+   * @return DOMDocument
+   *   A loaded XHTML document containing the text.
+   *
+   * @see filter_load_dom()
+   */
+  protected function document($text) {
+    $dom = new DOMDocument();
+    $dom_data = str_replace("@replace@", $text, $this->generalDom);
+    @$dom->loadXML($dom_data);
+    return $dom;
+  }
+
+  /**
+   * Truncate text according to input parameters.
+   *
+   * @param string $text
+   *   The string to truncate.
+   */
+  protected function truncateText($text) {
+    return truncate_utf8(
+      $text,
+      $this->truncationLength,
+      $this->wordSafe,
+      $this->addEllipsis,
+      $this->wordsafeLength
+    );
+  }
+
+  /**
+   * Process and close DOMElements as they appear in the Doc.
+   *
+   * @param DOMElement $el
+   *   The DOMElement to process.
+   * @param string $remaining
+   *   The max truncation length.
+   *
+   * @throws Exception
+   */
+  protected function process(DOMElement $el, &$remaining) {
+    foreach ($el->childNodes as $child) {
+      switch ($child->nodeType) {
+        case XML_ELEMENT_NODE:
+          if (!$child->namespaceURI || $child->namespaceURI === static::XHTML_URI) {
+            $this->writer->startElement($child->nodeName);
+          }
+          else {
+            $this->writer->startElementNS($child->prefix, $child->localName, $child->namespaceURI);
+          }
+          foreach ($child->attributes as $attribute) {
+            if ($attribute->namespaceURI) {
+              $this->writer->writeAttributeNS($attribute->prefix, $attribute->localName, $attribute->namespaceURI, $attribute->nodeValue);
+            }
+            else {
+              $this->writer->writeAttribute($attribute->nodeName, $attribute->nodeValue);
+            }
+          }
+          $this->process($child, $remaining);
+          $this->writer->endElement();
+          break;
+
+        case XML_TEXT_NODE:
+        case XML_CDATA_SECTION_NODE:
+          $current = $child->nodeValue;
+          $current_length = drupal_strlen($current);
+
+          $this->writer->text($this->truncateText($current, $remaining));
+          $remaining -= $current_length;
+          break;
+
+        default:
+          throw new Exception("Unhandled XML node type: $child->nodeType");
+      }
+      if ($remaining <= 0) {
+        return;
+      }
+    }
+  }
+
+  /**
+   * Return output to string.
+   */
+  public function __toString() {
+    return $this->output;
+  }
+
+}

--- a/includes/field_truncation.inc
+++ b/includes/field_truncation.inc
@@ -15,7 +15,7 @@ class IslandoraSolrFieldTruncation {
   protected $addEllipsis;
   protected $wordsafeLength;
 
-  protected $generalDom = <<<EOXML
+  const GENERAL_DOM = <<<EOXML
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
@@ -74,7 +74,7 @@ EOXML;
    */
   protected function document($text) {
     $dom = new DOMDocument();
-    $dom_data = str_replace("@replace@", $text, $this->generalDom);
+    $dom_data = str_replace("@replace@", $text, static::GENERAL_DOM);
     @$dom->loadXML($dom_data);
     return $dom;
   }

--- a/includes/field_truncation.inc
+++ b/includes/field_truncation.inc
@@ -84,11 +84,13 @@ EOXML;
    *
    * @param string $text
    *   The string to truncate.
+   * @param string $remaining
+   *   The remaining truncation length.
    */
   protected function truncateText($text, $remaining) {
     return truncate_utf8(
       $text,
-      $desired_length,
+      $remaining,
       $this->wordSafe,
       $this->addEllipsis,
       $this->wordsafeLength

--- a/includes/field_truncation.inc
+++ b/includes/field_truncation.inc
@@ -75,7 +75,13 @@ EOXML;
   protected function document($text) {
     $dom = new DOMDocument();
     $dom_data = str_replace("@replace@", $text, static::GENERAL_DOM);
-    @$dom->loadXML($dom_data);
+
+    // The dom can Fail to load on elements that are self
+    // closing (such as <br/>) or special chars like ><. This is why we choose
+    // to load the data as HTML instead.
+    if (!@$dom->loadXML($dom_data)) {
+      @$dom->loadHTML($dom_data);
+    }
     return $dom;
   }
 

--- a/includes/field_truncation.inc
+++ b/includes/field_truncation.inc
@@ -32,11 +32,11 @@ EOXML;
    *
    * @param string $text
    *   The text to truncate.
-   * @param string $desired_length
+   * @param int $desired_length
    *   The desired length to truncate to.
    * @param bool $word_safe
    *   Attempt to truncate on a word boundary.
-   * @param string $add_ellipsis
+   * @param bool $add_ellipsis
    *   Add '...' to the end of the truncated string.
    * @param int $wordsafe_length
    *   If $word_safe is true, the minimum acceptable length for truncation.
@@ -84,7 +84,7 @@ EOXML;
    *
    * @param string $text
    *   The string to truncate.
-   * @param string $remaining
+   * @param int $remaining
    *   The remaining truncation length.
    */
   protected function truncateText($text, $remaining) {
@@ -102,7 +102,7 @@ EOXML;
    *
    * @param DOMElement $el
    *   The DOMElement to process.
-   * @param string $remaining
+   * @param int $remaining
    *   The max truncation length.
    *
    * @throws Exception

--- a/includes/field_truncation.inc
+++ b/includes/field_truncation.inc
@@ -11,7 +11,6 @@
 class IslandoraSolrFieldTruncation {
   protected $writer;
   protected $output = '';
-  protected $truncationLength;
   protected $wordSafe;
   protected $addEllipsis;
   protected $wordsafeLength;
@@ -44,20 +43,19 @@ EOXML;
    *   No effect if $word_safe is false.
    */
   public function __construct($text, $desired_length, $word_safe = TRUE, $add_ellipsis = TRUE, $wordsafe_length = 1) {
-    $this->truncationLength = $desired_length;
     $this->wordSafe = $word_safe;
     $this->addEllipsis = $add_ellipsis;
     $this->wordsafeLength = $wordsafe_length;
 
     if (strpos($text, '<') === FALSE && strpos($text, '>') === FALSE) {
       // No apparent markup... No need for more processing.
-      $this->output = $this->truncateText($text);
+      $this->output = $this->truncateText($text, $desired_length);
       return;
     }
 
     $this->writer = new XMLWriter();
     $this->writer->openMemory();
-    $this->process($this->document($text)->getElementsByTagName('body')->item(0), $this->truncationLength);
+    $this->process($this->document($text)->getElementsByTagName('body')->item(0), $desired_length);
     $this->output = $this->writer->outputMemory();
   }
 
@@ -87,10 +85,10 @@ EOXML;
    * @param string $text
    *   The string to truncate.
    */
-  protected function truncateText($text) {
+  protected function truncateText($text, $remaining) {
     return truncate_utf8(
       $text,
-      $this->truncationLength,
+      $desired_length,
       $this->wordSafe,
       $this->addEllipsis,
       $this->wordsafeLength

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -529,7 +529,6 @@ function islandora_solr_truncate_field_display($display_values, $max_length, $ad
           '!field' => $link_options['field'],
           '!value' => islandora_solr_lesser_escape($original_value),
           ));
-
         $original_value = l(
           $original_value,
           "islandora/search/$solr_query",
@@ -537,7 +536,6 @@ function islandora_solr_truncate_field_display($display_values, $max_length, $ad
             'html' => TRUE,
           )
         );
-
         $truncated_value = l(
           $truncated_value,
           "islandora/search/$solr_query",
@@ -562,10 +560,6 @@ function islandora_solr_truncate_field_display($display_values, $max_length, $ad
     $updated_display_values .= '</span>';
 
   }
-  else {
-    $updated_display_values = '';
-  }
-
   return $updated_display_values;
 };
 

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -515,7 +515,7 @@ function islandora_solr_truncate_field_display($display_values, $max_length, $ad
       }
     }
 
-    // Ensure any markup that may exist in this field value is properly closed.
+    // Ensure any markup that may exist in this fields value is properly closed.
     $original_value = _filter_htmlcorrector(implode($separator, $updated_display_values));
     $truncated_value = _filter_htmlcorrector(implode($separator, $truncated_list));
 

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -302,6 +302,8 @@ function islandora_solr_prepare_solr_doc($object_results) {
  *   Returns the same array but with prepared Solr field values.
  */
 function islandora_solr_prepare_solr_results($solr_results) {
+  module_load_include('inc', 'islandora_solr', 'includes/field_truncation');
+
   $object_results = $solr_results['response']['objects'];
   $highlighting = isset($solr_results['highlighting']) ? $solr_results['highlighting'] : array();
   $fields_all = islandora_solr_get_fields('result_fields', FALSE);
@@ -364,11 +366,20 @@ function islandora_solr_prepare_solr_results($solr_results) {
           $tf =& $truncate_length[$field];
           $wordsafe = FALSE;
           $min_wordsafe_length = 1;
+
           if (isset($tf['wordsafe'])) {
             $wordsafe = $tf['wordsafe'];
             $min_wordsafe_length = $tf['wordsafe_length'];
           }
-          $val_val = truncate_utf8($val_val, $tf['maximum_length'], $wordsafe, $tf['add_ellipsis'], $min_wordsafe_length);
+
+          $val_val = new IslandoraSolrFieldTruncation(
+            $val_val,
+            $tf['maximum_length'],
+            $wordsafe,
+            $tf['add_ellipsis'],
+            $min_wordsafe_length
+          );
+
         };
         array_walk($value, $truncate_func);
       }
@@ -486,6 +497,8 @@ function islandora_solr_islandora_basic_collection_backend_callable($collection_
  *   The updated display values.
  */
 function islandora_solr_truncate_field_display($display_values, $max_length, $add_ellipsis, $word_safe, $wordsafe_length, $separator, $link_options = NULL) {
+  module_load_include('inc', 'islandora_solr', 'includes/field_truncation');
+
   $updated_display_values = $display_values;
   $separator = filter_xss($separator, islandora_solr_get_filter_tags());
 
@@ -509,15 +522,22 @@ function islandora_solr_truncate_field_display($display_values, $max_length, $ad
         if ($add_ellipsis) {
           $truncation_length = max($truncation_length, drupal_strlen(t('...')));
         }
-        $current_value = truncate_utf8($current_value, $truncation_length, $word_safe, $add_ellipsis, $wordsafe_length);
-        $truncated_list[] = $current_value;
+
+        $truncated_list[] = new IslandoraSolrFieldTruncation(
+          $current_value,
+          $truncation_length,
+          $word_safe,
+          $add_ellipsis,
+          $wordsafe_length
+        );
+
         break;
       }
     }
 
     // Ensure any markup that may exist in this fields value is properly closed.
-    $original_value = _filter_htmlcorrector(implode($separator, $updated_display_values));
-    $truncated_value = _filter_htmlcorrector(implode($separator, $truncated_list));
+    $original_value = implode($separator, $updated_display_values);
+    $truncated_value = implode($separator, $truncated_list);
 
     if ($link_options !== NULL) {
       if (isset($link_options['link_to_object']) && $link_options['link_to_object'] == TRUE) {

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -535,10 +535,8 @@ function islandora_solr_truncate_field_display($display_values, $max_length, $ad
       }
     }
 
-    // Ensure any markup that may exist in this fields value is properly closed.
     $original_value = implode($separator, $updated_display_values);
     $truncated_value = implode($separator, $truncated_list);
-
     if ($link_options !== NULL) {
       if (isset($link_options['link_to_object']) && $link_options['link_to_object'] == TRUE) {
         $original_value = l($original_value, $link_options['url'], $link_options['options']);

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -372,7 +372,7 @@ function islandora_solr_prepare_solr_results($solr_results) {
             $min_wordsafe_length = $tf['wordsafe_length'];
           }
 
-          $val_val = new IslandoraSolrFieldTruncation(
+          $val_val = (string) new IslandoraSolrFieldTruncation(
             $val_val,
             $tf['maximum_length'],
             $wordsafe,
@@ -523,7 +523,7 @@ function islandora_solr_truncate_field_display($display_values, $max_length, $ad
           $truncation_length = max($truncation_length, drupal_strlen(t('...')));
         }
 
-        $truncated_list[] = new IslandoraSolrFieldTruncation(
+        $truncated_list[] = (string) new IslandoraSolrFieldTruncation(
           $current_value,
           $truncation_length,
           $word_safe,

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -515,8 +515,10 @@ function islandora_solr_truncate_field_display($display_values, $max_length, $ad
       }
     }
 
-    $original_value = implode($separator, $updated_display_values);
-    $truncated_value = implode($separator, $truncated_list);
+    // Ensure any markup that may exist in this field value is properly closed.
+    $original_value = _filter_htmlcorrector(implode($separator, $updated_display_values));
+    $truncated_value = _filter_htmlcorrector(implode($separator, $truncated_list));
+
     if ($link_options !== NULL) {
       if (isset($link_options['link_to_object']) && $link_options['link_to_object'] == TRUE) {
         $original_value = l($original_value, $link_options['url'], $link_options['options']);
@@ -527,6 +529,7 @@ function islandora_solr_truncate_field_display($display_values, $max_length, $ad
           '!field' => $link_options['field'],
           '!value' => islandora_solr_lesser_escape($original_value),
           ));
+
         $original_value = l(
           $original_value,
           "islandora/search/$solr_query",
@@ -534,6 +537,7 @@ function islandora_solr_truncate_field_display($display_values, $max_length, $ad
             'html' => TRUE,
           )
         );
+
         $truncated_value = l(
           $truncated_value,
           "islandora/search/$solr_query",
@@ -558,6 +562,10 @@ function islandora_solr_truncate_field_display($display_values, $max_length, $ad
     $updated_display_values .= '</span>';
 
   }
+  else {
+    $updated_display_values = '';
+  }
+
   return $updated_display_values;
 };
 

--- a/islandora_solr.info
+++ b/islandora_solr.info
@@ -1,6 +1,5 @@
 name = Islandora Solr
 dependencies[] = islandora
-dependencies[] = filter
 description = Searches an Islandora Solr index
 package = Islandora Search
 configure = admin/config/islandora_solr

--- a/islandora_solr.info
+++ b/islandora_solr.info
@@ -1,5 +1,6 @@
 name = Islandora Solr
 dependencies[] = islandora
+dependencies[] = filter
 description = Searches an Islandora Solr index
 package = Islandora Search
 configure = admin/config/islandora_solr


### PR DESCRIPTION
**JIRA Ticket**: [ISLANDORA-2017](https://jira.duraspace.org/browse/ISLANDORA-2017)

# What does this Pull Request do?

When displaying a metadata field that is both truncated to a max length AND contains basic HTML tags, the 'Show more' and 'Show less' toggle can break the display. While modules that implement this functionality (such as islandora_solr_metadata) performs a check_markup() call in the template file (which uses the 'islandora_solr_metadata_filtered_html' text format for correctness), we should also be preforming a check like this on the raw truncated value of the field, as well as the full value of the field. This pull request will call the filter modules '_filter_htmlcorrector()' function to ensure metadata tags are correctly closed.

# What's new?
This pull request will add two calls to '_filter_htmlcorrector()' to be sure field content that contains markup will properly be closed, prior to attempting to link the field value in question (if configured to do so) or appending the show more/show less toggle.

# How should this be tested?

* Add metadata field content to an ingested objects field (such as 'description') that contains basic HTML
* Truncate the whole field to a max length, so that the max length falls between an opening and closing HTML tag
* View the field in a search result, or within the islandora_solr_metadata display

# Additional Notes:
It may also be worth noting, the islandora_solr_metadata module template is wrapping description data in a `<p>` tag, which should not semantically contain HTML tags [see here](https://github.com/Islandora/islandora_solr_metadata/blob/7.x/theme/islandora-solr-metadata-description.tpl.php#L24). While metadata fields do not typically include HTML tags, it is entirely possible they will.

* Could this change impact execution of existing code?
I do not _believe_ this change will change the execution of existing code, however it could change the fields display if said field already contains basic html, and the islandora_solr_metadata_filtered_html text formatter is configured to allow it.

# Interested parties
Taging @nhart  @Islandora/7-x-1-x-committers  