### PR TITLE
Update external documentation URLs

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -66,7 +66,7 @@ check if IslandoraSolrQueryProcessor::display is set, which is not ideal.
 - update hook_help functions
 - add a parameter to the luke function to return a single document.
 - check if spaces could be replaced by + or %20 , which would simplify some functions (splitting strings)
-https://lucene.apache.org/solr/guide/6_6/common-query-parameters.html#CommonQueryParameters-ThesortParameter
+http://archive.apache.org/dist/lucene/solr/ref-guide/
 - don't hardcode php solr library, instead override it.
 - add ajax_command_changed() to the vertical tabs to show something has changed.
 - add watchdog messages on error.

--- a/TODO.txt
+++ b/TODO.txt
@@ -66,7 +66,7 @@ check if IslandoraSolrQueryProcessor::display is set, which is not ideal.
 - update hook_help functions
 - add a parameter to the luke function to return a single document.
 - check if spaces could be replaced by + or %20 , which would simplify some functions (splitting strings)
-http://wiki.apache.org/solr/CommonQueryParameters#sort
+https://lucene.apache.org/solr/guide/6_6/common-query-parameters.html#CommonQueryParameters-ThesortParameter
 - don't hardcode php solr library, instead override it.
 - add ajax_command_changed() to the vertical tabs to show something has changed.
 - add watchdog messages on error.

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -603,7 +603,7 @@ function islandora_solr_admin_settings($form, &$form_state) {
     '#description' => t('Indicates which field should define the sort order for the default query.<br />
     For example: <strong>fgs_createdDate_dt desc</strong>.<br /><strong>Note:</strong> only single-valued fields are sortable.
     For more information, check the <a href="!url">Solr documentation</a>.',
-      array('!url' => 'http://wiki.apache.org/solr/CommonQueryParameters#sort')),
+      array('!url' => 'https://lucene.apache.org/solr/guide/6_6/common-query-parameters.html#CommonQueryParameters-ThesortParameter')),
     '#default_value' => variable_get('islandora_solr_base_sort', ''),
   );
   $form['islandora_solr_tabs']['query_defaults']['islandora_solr_base_filter'] = array(
@@ -619,7 +619,7 @@ function islandora_solr_admin_settings($form, &$form_state) {
     '#title' => t('Query fields'),
     '#default_value' => variable_get('islandora_solr_query_fields', 'dc.title^5 dc.subject^2 dc.description^2 dc.creator^2 dc.contributor^1 dc.type'),
     '#description' => t('<a href="@url" target="_blank" title="Solr query fields documentation">Query fields</a> to use for DisMax (simple) searches.', array(
-      '@url' => 'http://wiki.apache.org/solr/DisMaxQParserPlugin#qf_.28Query_Fields.29',
+      '@url' => 'https://lucene.apache.org/solr/guide/6_6/the-dismax-query-parser.html#TheDisMaxQueryParser-Theqf_QueryFields_Parameter',
     )),
   );
   $form['islandora_solr_tabs']['query_defaults']['islandora_solr_use_ui_qf'] = array(

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -602,8 +602,8 @@ function islandora_solr_admin_settings($form, &$form_state) {
     '#size' => 30,
     '#description' => t('Indicates which field should define the sort order for the default query.<br />
     For example: <strong>fgs_createdDate_dt desc</strong>.<br /><strong>Note:</strong> only single-valued fields are sortable.
-    For more information, check the <a href="!url">Solr documentation</a>.',
-      array('!url' => 'https://lucene.apache.org/solr/guide/6_6/common-query-parameters.html#CommonQueryParameters-ThesortParameter')),
+    For more information, see "sort" as discussed in the "Common query parameters" section of the 
+    <a href="!url">Solr documentation</a>.', array('!url' => 'http://archive.apache.org/dist/lucene/solr/ref-guide/')),
     '#default_value' => variable_get('islandora_solr_base_sort', ''),
   );
   $form['islandora_solr_tabs']['query_defaults']['islandora_solr_base_filter'] = array(
@@ -618,8 +618,8 @@ function islandora_solr_admin_settings($form, &$form_state) {
     '#type' => 'textarea',
     '#title' => t('Query fields'),
     '#default_value' => variable_get('islandora_solr_query_fields', 'dc.title^5 dc.subject^2 dc.description^2 dc.creator^2 dc.contributor^1 dc.type'),
-    '#description' => t('<a href="@url" target="_blank" title="Solr query fields documentation">Query fields</a> to use for DisMax (simple) searches.', array(
-      '@url' => 'https://lucene.apache.org/solr/guide/6_6/the-dismax-query-parser.html#TheDisMaxQueryParser-Theqf_QueryFields_Parameter',
+    '#description' => t('Query fields to use for DisMax (simple) searches. See the QueryFields section in the <a href="@url" target="_blank" title="Solr documentation">Solr documentation</a> for examples.', array(
+      '@url' => 'http://archive.apache.org/dist/lucene/solr/ref-guide/',
     )),
   );
   $form['islandora_solr_tabs']['query_defaults']['islandora_solr_use_ui_qf'] = array(

--- a/includes/blocks.inc
+++ b/includes/blocks.inc
@@ -886,7 +886,8 @@ function islandora_solr_sort() {
     }
     else {
       // If no parameters are given, internally solr defaults to 'score desc'
-      // https://lucene.apache.org/solr/guide/6_6/common-query-parameters.html#CommonQueryParameters-ThesortParameter
+      // https://lucene.apache.org/solr/guide/6_6/common-query-parameters.html
+      // #CommonQueryParameters-ThesortParameter
       $current_sort_term = 'score';
       $current_sort_order = 'desc';
     }

--- a/includes/blocks.inc
+++ b/includes/blocks.inc
@@ -885,9 +885,9 @@ function islandora_solr_sort() {
       $current_sort_order = isset($sort_explode[1]) ? $sort_explode[1] : NULL;
     }
     else {
-      // If no parameters are given, internally solr defaults to 'score desc'
-      // https://lucene.apache.org/solr/guide/6_6/common-query-parameters.html
-      // #CommonQueryParameters-ThesortParameter
+      // If no parameters are given, internally solr defaults to 'score desc'. 
+      // See Common Query Paremeters section:
+      // http://archive.apache.org/dist/lucene/solr/ref-guide/
       $current_sort_term = 'score';
       $current_sort_order = 'desc';
     }

--- a/includes/blocks.inc
+++ b/includes/blocks.inc
@@ -886,7 +886,7 @@ function islandora_solr_sort() {
     }
     else {
       // If no parameters are given, internally solr defaults to 'score desc'
-      // http://wiki.apache.org/solr/CommonQueryParameters#sort
+      // https://lucene.apache.org/solr/guide/6_6/common-query-parameters.html#CommonQueryParameters-ThesortParameter
       $current_sort_term = 'score';
       $current_sort_order = 'desc';
     }

--- a/includes/blocks.inc
+++ b/includes/blocks.inc
@@ -885,7 +885,7 @@ function islandora_solr_sort() {
       $current_sort_order = isset($sort_explode[1]) ? $sort_explode[1] : NULL;
     }
     else {
-      // If no parameters are given, internally solr defaults to 'score desc'. 
+      // If no parameters are given, internally solr defaults to 'score desc'.
       // See Common Query Paremeters section:
       // http://archive.apache.org/dist/lucene/solr/ref-guide/
       $current_sort_term = 'score';

--- a/includes/luke.inc
+++ b/includes/luke.inc
@@ -131,9 +131,8 @@ function islandora_solr_get_luke($solr_url = NULL, $field = NULL, $num_terms = 0
  * Returns an array containing all fields in Luke that are sortable.
  *
  * Must be indexed and can't be multivalued.
- * @link https://lucene.apache.org/solr/guide/6_6/common-query-parameters.html
- * #CommonQueryParameters-ThesortParameter 
- * More info on constraints. @endlink
+ * @link http://archive.apache.org/dist/lucene/solr/ref-guide/ 
+ * Common Query Parameters: Sort section for more info on constraints. @endlink
  *
  * @param string $solr_url
  *   URL which points to Solr.

--- a/includes/luke.inc
+++ b/includes/luke.inc
@@ -131,7 +131,8 @@ function islandora_solr_get_luke($solr_url = NULL, $field = NULL, $num_terms = 0
  * Returns an array containing all fields in Luke that are sortable.
  *
  * Must be indexed and can't be multivalued.
- * @link http://wiki.apache.org/solr/CommonQueryParameters#sort More info on constraints. @endlink
+ * @link https://lucene.apache.org/solr/guide/6_6/common-query-parameters.html#CommonQueryParameters-ThesortParameter 
+ * More info on constraints. @endlink
  *
  * @param string $solr_url
  *   URL which points to Solr.

--- a/includes/luke.inc
+++ b/includes/luke.inc
@@ -131,7 +131,8 @@ function islandora_solr_get_luke($solr_url = NULL, $field = NULL, $num_terms = 0
  * Returns an array containing all fields in Luke that are sortable.
  *
  * Must be indexed and can't be multivalued.
- * @link https://lucene.apache.org/solr/guide/6_6/common-query-parameters.html#CommonQueryParameters-ThesortParameter 
+ * @link https://lucene.apache.org/solr/guide/6_6/common-query-parameters.html
+ * #CommonQueryParameters-ThesortParameter 
  * More info on constraints. @endlink
  *
  * @param string $solr_url


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-2034)

# What does this Pull Request do?
Updates references to the Apache Solr Wiki to its new location (which changed June 2017)

# What's new?
External links to the documentation on Solr fields, specifically Sort and DisMax, updated to the new location of the Solr guide.

# How should this be tested?

Go to the Solr config pages and make sure that the external links go to the right places.

# Interested parties
@Islandora/7-x-1-x-committers 
