### PR TITLE
ISLANDORA-1573: Make port number required in Solr URL

### DIFF
--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -44,8 +44,8 @@ function islandora_solr_admin_index_settings($form, &$form_state) {
       $solr_avail = FALSE;
     }
     elseif (preg_match('/^([^\/]+):/', $solr_url) === 0) {
-        form_set_error('islandora_solr_url', t('Port number required in Solr URL.'));
-        $solr_avail = FALSE;
+      form_set_error('islandora_solr_url', t('Port number required in Solr URL.'));
+      $solr_avail = FALSE;
     }
     else {
       // Check if Solr is available.

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -43,6 +43,10 @@ function islandora_solr_admin_index_settings($form, &$form_state) {
       ));
       $solr_avail = FALSE;
     }
+    elseif (preg_match('/^([^\/]+):/', $solr_url) === 0) {
+        form_set_error('islandora_solr_url', t('Port number required in Solr URL.'));
+        $solr_avail = FALSE;
+    }
     else {
       // Check if Solr is available.
       $solr_avail = islandora_solr_ping($solr_url);
@@ -93,7 +97,7 @@ function islandora_solr_admin_index_settings($form, &$form_state) {
     '#title' => t('Solr URL'),
     '#size' => 80,
     '#weight' => -1,
-    '#description' => t('The URL of the Solr installation. Defaults to localhost:8080/solr.'),
+    '#description' => t('The URL of the Solr installation. Defaults to localhost:8080/solr.  Port number (e.g. ":8080") is required.'),
     '#default_value' => $solr_url,
     '#required' => TRUE,
     '#ajax' => array(


### PR DESCRIPTION
Fixes ISLANDORA-1573

**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1573

* [Previous Pull Request \#262 · Islandora/islandora\_solr\_search](https://github.com/Islandora/islandora_solr_search/pull/262)

# What does this Pull Request do?

Requires a port number in the Solr URL.

# What's new?

Added code in form validation to test whether a colon appears before a slash, implying that a port number is specified before a path.

# How should this be tested?

Modify the Solr URL so that it doesn't include a colon followed by a port number, then leave the focus of that form field.  The form should refresh and display an error message that the port number is required.

# Additional Notes:

Earlier attempts (#262) modified code to set a default port number (for http and https) if a port number wasn't specified.  It was decided to move this to an explicit test in the admin form to make sure a port was specified.

# Interested parties
Participants in the previous pull request: @jordandukart, @whikloj, and @DiegoPino.
