### PR TITLE
ISLANDORA-2113 Invalid Solr breadcrumb queries

### DIFF
--- a/includes/breadcrumbs.inc
+++ b/includes/breadcrumbs.inc
@@ -104,8 +104,10 @@ function islandora_solr_get_breadcrumbs_recursive($pid, array &$context = NULL) 
 function islandora_solr_get_breadcrumb_parent($pid) {
   module_load_include('inc', 'islandora_solr', 'includes/query_processor');
   $solr_build = new IslandoraSolrQueryProcessor();
-  $solr_query = "PID:(" . islandora_solr_lesser_escape($pid) . " OR " .
-    islandora_solr_lesser_escape("info:fedora/" . $pid) . ")";
+  $solr_query = format_string('PID:("!pid" OR "!uri")', array(
+    '!pid' => islandora_solr_lesser_escape($pid),
+    '!uri' => islandora_solr_lesser_escape("info:fedora/{$pid}"),
+  ));
   $parent_fields = preg_split("/\\r\\n|\\n|\\r/", variable_get('islandora_solr_breadcrumbs_parents', "RELS_EXT_isMemberOfCollection_uri_ms\r\nRELS_EXT_isMemberOf_uri_ms"), -1, PREG_SPLIT_NO_EMPTY);
   $solr_params = array(
     'fl' => implode(",", $parent_fields) . ',fgs_label_s,PID',

--- a/includes/breadcrumbs.inc
+++ b/includes/breadcrumbs.inc
@@ -104,9 +104,8 @@ function islandora_solr_get_breadcrumbs_recursive($pid, array &$context = NULL) 
 function islandora_solr_get_breadcrumb_parent($pid) {
   module_load_include('inc', 'islandora_solr', 'includes/query_processor');
   $solr_build = new IslandoraSolrQueryProcessor();
-  $solr_query = format_string('PID:("!pid" OR "!uri")', array(
+  $solr_query = format_string('PID:"!pid"', array(
     '!pid' => $pid,
-    '!uri' => "info:fedora/{$pid}",
   ));
   $parent_fields = preg_split("/\\r\\n|\\n|\\r/", variable_get('islandora_solr_breadcrumbs_parents', "RELS_EXT_isMemberOfCollection_uri_ms\r\nRELS_EXT_isMemberOf_uri_ms"), -1, PREG_SPLIT_NO_EMPTY);
   $solr_params = array(

--- a/includes/breadcrumbs.inc
+++ b/includes/breadcrumbs.inc
@@ -105,8 +105,8 @@ function islandora_solr_get_breadcrumb_parent($pid) {
   module_load_include('inc', 'islandora_solr', 'includes/query_processor');
   $solr_build = new IslandoraSolrQueryProcessor();
   $solr_query = format_string('PID:("!pid" OR "!uri")', array(
-    '!pid' => islandora_solr_lesser_escape($pid),
-    '!uri' => islandora_solr_lesser_escape("info:fedora/{$pid}"),
+    '!pid' => $pid,
+    '!uri' => "info:fedora/{$pid}",
   ));
   $parent_fields = preg_split("/\\r\\n|\\n|\\r/", variable_get('islandora_solr_breadcrumbs_parents', "RELS_EXT_isMemberOfCollection_uri_ms\r\nRELS_EXT_isMemberOf_uri_ms"), -1, PREG_SPLIT_NO_EMPTY);
   $solr_params = array(


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2113

# What does this Pull Request do?

Ensures that the solr breadcrumb query uses double quotes.

This is an example of how the query parameter is currently being built:
`PID:(islandora\:root OR info\:fedora\/islandora\:root)`

And an example query parameter with the code adjustments made:
`PID:("islandora:root" OR "info:fedora/islandora:root")`

# How should this be tested?
- Ensure you're running a test environment which runs a version of solr that has the eDismax query parser.
- If it isn't already, enable Solr generated breadcrumbs (admin/islandora/configure)
- Add this [gist](https://gist.github.com/BrandonMorr/e29543af1bd29458e77e5bb6956500e8) to your islandora_solr.module
- Browse to a collection that has 2 or 3 parent's which should render breadcrumbs. Only the 'Browse' breadcrumb will be displayed
- Pull down the changes and re-add the code from the gist
- Repeat the 4th step. All breadcrumbs will be rendered

# Interested parties
@Islandora/7-x-1-x-committers