### PR TITLE
Use the name we store the variable with to get it back.

### DIFF
--- a/includes/breadcrumbs.inc
+++ b/includes/breadcrumbs.inc
@@ -107,7 +107,7 @@ function islandora_solr_get_breadcrumb_parent($pid) {
   $solr_query = format_string('PID:"!pid"', array(
     '!pid' => $pid,
   ));
-  $parent_fields = preg_split("/\\r\\n|\\n|\\r/", variable_get('islandora_solr_breadcrumbs_parents', "RELS_EXT_isMemberOfCollection_uri_ms\r\nRELS_EXT_isMemberOf_uri_ms"), -1, PREG_SPLIT_NO_EMPTY);
+  $parent_fields = preg_split("/\\r\\n|\\n|\\r/", variable_get('islandora_solr_breadcrumbs_parent_fields', "RELS_EXT_isMemberOfCollection_uri_ms\r\nRELS_EXT_isMemberOf_uri_ms"), -1, PREG_SPLIT_NO_EMPTY);
   $solr_params = array(
     'fl' => implode(",", $parent_fields) . ',fgs_label_s,PID',
     'hl' => 'false',


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2168

# What does this Pull Request do?

Fixes my stupid mistake

# What's new?
The configuration form [here](https://github.com/Islandora/islandora_solr_search/blob/7.x/includes/admin.inc#L1088-L1093) uses the variable name `islandora_solr_breadcrumbs_parent_fields` but for whatever reason in the actual code I used `islandora_solr_breadcrumb_parents`.

I guess no one has ever tried to adjust this setting before.

# How should this be tested?

Try to generate breadcrumbs for a compound (RELS_EXT_isConstituentOf_uri_ms) and view a part of that compound or try **not** to generate breadcrumbs for say RELS_EXT_isMemberOfCollection_uri_ms. 

I bet it doesn't work.

# Additional Notes:

Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@Islandora/7-x-1-x-committers
