### PR TITLE
ISLANDORA-2181:Boolean Query on Solr Collection display generates issues with some query handler settings

### DIFF
--- a/css/islandora_solr.theme.css
+++ b/css/islandora_solr.theme.css
@@ -55,6 +55,7 @@ dl.solr-fields
 .solr-fields dd
 {
   border-top: 1px solid #ddd;
+  word-wrap: break-word;
 }
 
 .solr-fields dt.first,

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -466,13 +466,13 @@ function islandora_solr_islandora_basic_collection_backend_callable($collection_
   $pid = $collection_object->id;
   $member_of = variable_get('islandora_solr_member_of_field', 'RELS_EXT_isMemberOf_uri_ms');
   $member_of_collection = variable_get('islandora_solr_member_of_collection_field', 'RELS_EXT_isMemberOfCollection_uri_ms');
-  $filters = array(
-    format_string('!member_of_collection:("!iripid" OR "!pid") OR (!member_of:"!iripid" OR "!pid")', array(
+  $filters = format_string('!member_of_collection:("!iripid" OR "!pid") OR (!member_of:"!iripid" OR "!pid")',
+    array(
       '!member_of_collection' => $member_of_collection,
       '!iripid' => "info:fedora/$pid",
       '!pid' => $pid,
       '!member_of' => $member_of,
-    )),
+    )
   );
   $qp->solrParams['fq'][] = $filters;
 

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -461,12 +461,13 @@ function islandora_solr_islandora_basic_collection_backend_callable($collection_
   global $_islandora_solr_queryclass;
   $qp = new IslandoraSolrQueryProcessor();
   $_islandora_solr_queryclass = $qp;
-
-  $qp->buildQuery(format_string('!member_field:("info:fedora/!pid" OR "!pid") OR !collection_member_field:("info:fedora/!pid" OR "!pid")', array(
+  dpm(drupal_get_query_parameters());
+  $qp->buildQuery("*:*", drupal_get_query_parameters());
+  $qp->solrParams['fq'][] = format_string('!member_field:("info:fedora/!pid" OR "!pid") OR !collection_member_field:("info:fedora/!pid" OR "!pid")', array(
     '!member_field' => variable_get('islandora_solr_member_of_field', 'RELS_EXT_isMemberOf_uri_ms'),
     '!pid' => $collection_object->id,
     '!collection_member_field' => variable_get('islandora_solr_member_of_collection_field', 'RELS_EXT_isMemberOfCollection_uri_ms'),
-  )), drupal_get_query_parameters());
+  ));
 
   if (variable_get('islandora_solr_collection_result_limit_block_override', FALSE)) {
     if (isset($qp->internalSolrParams['limit'])) {

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -463,6 +463,7 @@ function islandora_solr_islandora_basic_collection_backend_callable($collection_
   $_islandora_solr_queryclass = $qp;
 
   $qp->buildQuery("*:*", drupal_get_query_parameters());
+  $pid = $collection_object->id;
   $member_of = variable_get('islandora_solr_member_of_field', 'RELS_EXT_isMemberOf_uri_ms');
   $member_of_collection = variable_get('islandora_solr_member_of_collection_field', 'RELS_EXT_isMemberOfCollection_uri_ms');
   $filters = array(

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -473,7 +473,7 @@ function islandora_solr_islandora_basic_collection_backend_callable($collection_
       '!member_of' => $member_of,
     )),
   );
-  $qp->solrParams['fq'] = $filters;
+  $qp->solrParams['fq'][] = $filters;
 
   if (variable_get('islandora_solr_collection_result_limit_block_override', FALSE)) {
     if (isset($qp->internalSolrParams['limit'])) {

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -461,7 +461,7 @@ function islandora_solr_islandora_basic_collection_backend_callable($collection_
   global $_islandora_solr_queryclass;
   $qp = new IslandoraSolrQueryProcessor();
   $_islandora_solr_queryclass = $qp;
-  dpm(drupal_get_query_parameters());
+
   $qp->buildQuery("*:*", drupal_get_query_parameters());
   $qp->solrParams['fq'][] = format_string('!member_field:("info:fedora/!pid" OR "!pid") OR !collection_member_field:("info:fedora/!pid" OR "!pid")', array(
     '!member_field' => variable_get('islandora_solr_member_of_field', 'RELS_EXT_isMemberOf_uri_ms'),

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -467,9 +467,10 @@ function islandora_solr_islandora_basic_collection_backend_callable($collection_
   $member_of = variable_get('islandora_solr_member_of_field', 'RELS_EXT_isMemberOf_uri_ms');
   $member_of_collection = variable_get('islandora_solr_member_of_collection_field', 'RELS_EXT_isMemberOfCollection_uri_ms');
   $filters = array(
-    format_string('!member_of_collection:"!pid" OR !member_of:"!pid"', array(
+    format_string('!member_of_collection:("!iripid" OR "!pid") OR (!member_of:"!iripid" OR "!pid")', array(
       '!member_of_collection' => $member_of_collection,
-      '!pid' => "info:fedora/$pid",
+      '!iripid' => "info:fedora/$pid",
+      '!pid' => $pid,
       '!member_of' => $member_of,
     )),
   );

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -463,11 +463,16 @@ function islandora_solr_islandora_basic_collection_backend_callable($collection_
   $_islandora_solr_queryclass = $qp;
 
   $qp->buildQuery("*:*", drupal_get_query_parameters());
-  $qp->solrParams['fq'][] = format_string('!member_field:("info:fedora/!pid" OR "!pid") OR !collection_member_field:("info:fedora/!pid" OR "!pid")', array(
-    '!member_field' => variable_get('islandora_solr_member_of_field', 'RELS_EXT_isMemberOf_uri_ms'),
-    '!pid' => $collection_object->id,
-    '!collection_member_field' => variable_get('islandora_solr_member_of_collection_field', 'RELS_EXT_isMemberOfCollection_uri_ms'),
-  ));
+  $member_of = variable_get('islandora_solr_member_of_field', 'RELS_EXT_isMemberOf_uri_ms');
+  $member_of_collection = variable_get('islandora_solr_member_of_collection_field', 'RELS_EXT_isMemberOfCollection_uri_ms');
+  $filters = array(
+    format_string('!member_of_collection:"!pid" OR !member_of:"!pid"', array(
+      '!member_of_collection' => $member_of_collection,
+      '!pid' => "info:fedora/$pid",
+      '!member_of' => $member_of,
+    )),
+  );
+  $qp->solrParams['fq'] = $filters;
 
   if (variable_get('islandora_solr_collection_result_limit_block_override', FALSE)) {
     if (isset($qp->internalSolrParams['limit'])) {


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-2181)

# What does this Pull Request do?

Moves a Solr query statement to a Filter Query in our Solr Collection display to allow some pretty edge (but still feasible) query handler settings to be possible without breaking collection listing

# What's new?
Instead of a query with lots of OR conditionals we now do a wildcard query with a simpler filter query statement

# How should this be tested?

## The why is this needed test:
You can test the condition directly via a  [Solr query ](http://localhost:8080/solr/collection1/select?mm=100%25&q.op=AND&sort=fgs_label_s+asc&facet=true&facet.mincount=2&facet.limit=20&facet.field=mods_subject_temporal_ms&facet.field=mods_relatedItem_host_titleInfo_title_ms&facet.field=mods_name_namePart_ms&facet.field=mods_subject_geographic_ms&facet.field=mods_subject_topic_ms&facet.field=mods_genre_ms&fq=-RELS_EXT_isConstituentOf_uri_mt%3A%5B%2A+TO+%2A%5D&fq=RELS_EXT_isViewableByUser_literal_ms%3A%22anonymous%22+OR+RELS_EXT_isViewableByRole_literal_ms%3A%22anonymous+user%22+OR+%28%28%2A%3A%2A+-RELS_EXT_isViewableByUser_literal_ms%3A%5B%2A+TO+%2A%5D%29+AND+%28%2A%3A%2A+-RELS_EXT_isViewableByRole_literal_ms%3A%5B%2A+TO+%2A%5D%29%29&version=1.2&wt=json&json.nl=map&q=RELS_EXT_isMemberOf_uri_ms%3A%28%22info%3Afedora%2Fislandora%3Aroot%22+OR+%22islandora%3Aroot%22%29+OR+RELS_EXT_isMemberOfCollection_uri_ms%3A%28%22info%3Afedora%2Fislandora%3Aroot%22+OR+%22islandora%3Aroot%22%29&start=0&rows=50&indent=on&debugQuery=true)
You should see 0 results.
 
Or you can follow this steps

A) Go to your solrconfig.xml file, and edit default query handler putting this in place
```XML
<requestHandler name="/select" class="solr.SearchHandler">
    <!-- default values for query parameters can be specified, these
         will be overridden by parameters in the request
      -->
    <lst name="defaults">
      <str name="echoParams">explicit</str>
      <int name="rows">10</int>
      <str name="mm">100%</str>
      <str name="q">*:*</str>
      <str name="q.op">AND</str>
      <str name="defType">edismax</str>
     <str name="qf">dc.title^5</str> 
  </lst> 
</requestHandler>
````
and restart your Solr.

- if you have Solr Display enabled in your Collection Solution pack configuration:
  - Go to any islandora collection, they should appear empty 😿 
  - Change <str name="mm">100%</str> to <str name="mm">90%</str>
  - Now your collections are not empty anymore 😃 
- If not, enable it!  

## The " this patch fixes the issue"

- Go back to 100% on mm
- Apply this patch
- All is good, you can see your objects inside any collection.

## The All still works test even if you are never ever touching `solrconfig.xml`
Roll all your Solr changes back, restart Solr.
B) if you have Solr Display enabled in your Collection Solution pack configuration:
Check how many objects and their order in any collection are shown
Apply this patch
Check again. Should be the same



# Additional Notes:
Since I was here, I also added a thing to CSS that was bothering me since my early childhood: on a not configured Solr index, any search display shows all fields per object with their real names. They are normally long and overflow the enclosing table generating a scrambled display. This won't affect anyone badly (sorry I could not resist myself)

I removed the query that also checks for PID and `info:fedora/PID`. We have the same `fq` in many other places and we always assume these two Solr fields contain PIDs in `info:fedora/PID` format.

Please squash if you are ok with this change, I had a long day and I almost embarrass myself with this pull.

I have concerns about performance degradation here, so any recommendation will be appreciated.

# Interested parties
@whikloj @rosiel @adam-vessey  @Islandora/7-x-1-x-committers