### PR TITLE
Remove default dc.title from advanced search

### DIFF
--- a/includes/blocks.inc
+++ b/includes/blocks.inc
@@ -623,7 +623,6 @@ function islandora_solr_advanced_search_form($form, &$form_state) {
     $term['field'] = array(
       '#title' => t('Field'),
       '#type' => 'select',
-      '#default_value' => isset($value['field']) ? $value['field'] : 'dc.title',
       '#options' => islandora_solr_get_fields('search_fields'),
     );
     $term['search'] = array(

--- a/includes/blocks.inc
+++ b/includes/blocks.inc
@@ -623,6 +623,7 @@ function islandora_solr_advanced_search_form($form, &$form_state) {
     $term['field'] = array(
       '#title' => t('Field'),
       '#type' => 'select',
+      '#default_value' => isset($value['field']) ? $value['field'] : NULL,
       '#options' => islandora_solr_get_fields('search_fields'),
     );
     $term['search'] = array(


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-2204)

# What does this Pull Request do?

In 7.x, the Advanced Search Block selects the dc.title field by default, regardless of how the fields are arranged - unless of course there is no dc.title configured for Advanced Search. 

This change removes that default. Instead, the default selection is the first item in the list of Advanced Search fields, which can be configured by the administrator (instead of forcing dc.title). This is the same as occurs when the administrator does not configure dc.title as one of the Advanced Search fields.

# What's new?
Possible side-effects: If someone is relying on dc.title being the default selected field, and it's not the first in their drop-down, they will have to rearrange their drop-down. I imagine this would be an edge case, and regardless would not break anybody's repository.

# How should this be tested?

1. Set up an advanced search page with the advanced search block on it.
2. Select several fields, without dc.date
3. View your page, see the default-selected field (it will be the first field in your list)
4. Add dc.title to your list of fields, put it anywhere but the top.
5. Observe that dc.title is now the default selected field.
6. Check out this branch.
7. Look at your advanced search page again. The default selected field should once again be the first field you've configured.

A description of what steps someone could take to:
* Reproduce the problem you are fixing (if applicable)
* Test that the Pull Request does what is intended.
* Please be as detailed as possible.
* Good testing instructions help get your PR completed faster.

@DiegoPino @rosiel @Islandora/7-x-1-x-committers
