### PR TITLE
Improve default query sort string helptext

### DIFF
--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -604,9 +604,10 @@ function islandora_solr_admin_settings($form, &$form_state) {
     '#type' => 'textfield',
     '#title' => t('Sort field for default query'),
     '#size' => 30,
-    '#description' => t('Indicates which field should define the sort order for the default query.<br />
-    For example: <strong>fgs_createdDate_dt desc</strong>.<br /><strong>Note:</strong> only single-valued fields are sortable.
-    For more information, see "sort" as discussed in the "Common query parameters" section of the 
+    '#description' => t('Indicates which field(s) should define the sort order for the default query.<br />
+    For example: <strong>score desc, fgs_createdDate_dt desc</strong> will sort first by score, then by ingest date.<br />
+    <strong>Note:</strong> only single-valued fields are sortable. Sorting by fields other than "score" will affect relevance.
+    <br />For more information, see "sort" as discussed in the "Common query parameters" section of the 
     <a href="!url">Solr documentation</a>.', array('!url' => 'http://archive.apache.org/dist/lucene/solr/ref-guide/')),
     '#default_value' => variable_get('islandora_solr_base_sort', ''),
   );

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -602,7 +602,7 @@ function islandora_solr_admin_settings($form, &$form_state) {
   );
   $form['islandora_solr_tabs']['query_defaults']['islandora_solr_base_sort'] = array(
     '#type' => 'textfield',
-    '#title' => t('Sort field for search results'),
+    '#title' => t('Sort field(s) for search results'),
     '#size' => 30,
     '#description' => t('Indicates which field(s) should define the sort order for the search results.<br />
     For example: <strong>score desc, fgs_createdDate_dt desc</strong> will sort first by score, then by ingest date.<br />

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -602,9 +602,9 @@ function islandora_solr_admin_settings($form, &$form_state) {
   );
   $form['islandora_solr_tabs']['query_defaults']['islandora_solr_base_sort'] = array(
     '#type' => 'textfield',
-    '#title' => t('Sort field for default query'),
+    '#title' => t('Sort field for search results'),
     '#size' => 30,
-    '#description' => t('Indicates which field(s) should define the sort order for the default query.<br />
+    '#description' => t('Indicates which field(s) should define the sort order for the search results.<br />
     For example: <strong>score desc, fgs_createdDate_dt desc</strong> will sort first by score, then by ingest date.<br />
     <strong>Note:</strong> only single-valued fields are sortable. Sorting by fields other than "score" will affect relevance.
     <br />For more information, see "sort" as discussed in the "Common query parameters" section of the 


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-2233)

# What does this Pull Request do?

Improves the helptext for the Default query sort field in the admin form, to make it clear that "score desc" is necessary to include for relevance, and to illustrate how to include multiple fields for sorting.

# What's new?
A bit more in the help text.

# How should this be tested?

Read it, make sure it's clear and makes sense.

# Interested parties
@Islandora/7-x-1-x-committers
