### PR TITLE
ISLANDORA-2241: Page arguments for islandora/search menu item & Display profile logic cleanup

### DIFF
--- a/islandora_solr.module
+++ b/islandora_solr.module
@@ -33,6 +33,7 @@ function islandora_solr_menu() {
   $items['islandora/search'] = array(
     'title' => 'Search results',
     'page callback' => 'islandora_solr',
+    'page arguments' => array(2, NULL),
     'access arguments' => array('search islandora solr'),
     'type' => MENU_CALLBACK,
   );
@@ -283,14 +284,20 @@ function islandora_solr($query = NULL, $params = NULL) {
   // Set primary display.
   // Check if display param is an valid, enabled profile; otherwise, show
   // default.
-  if (isset($params['display']) && in_array($params['display'], $enabled_profiles)) {
-    $islandora_solr_primary_display = $params['display'];
+  if (isset($params['display'])) {
+    if (in_array($params['display'], $enabled_profiles)) {
+      $islandora_solr_primary_display = $params['display'];
+    }
+    else {
+      // Unset invalid parameter.
+      unset($params['display']);
+    }
   }
-  else {
+
+  if (empty($islandora_solr_primary_display)) {
     $islandora_solr_primary_display = variable_get('islandora_solr_primary_display', 'default');
-    // Unset invalid parameter.
-    unset($params['display']);
   }
+
   $params['islandora_solr_search_navigation'] = variable_get('islandora_solr_search_navigation', FALSE);
 
   // !!! Set the global variable. !!!


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2241

# What does this Pull Request do?

Backslashes are automatically converted to forward slashes by browsers when sending a page request off. As such, Drupal treats anything after the first slash as additional `$params` which cause Fatal PHP errors to be thrown. This pull aims to prevent the Fatal errors from occurring by using page arguments for the menu item, as well as logic cleanup for display profiles.

# What's new?
* Changed the 'Solr results' menu item to use page arguments to be passed off to the `islandora_solr()` callback function.
* Logic cleanup for display profiles - properly unset invalid `$params['display']` and properly fallback on default display profile.

# How should this be tested?
### NOTE: Do not test this with the Islandora Usage Stats module enabled (It alters the search menu path and prevents the errors from being thrown).
* Make a fielded search that includes a backslash somewhere in the search term, e.g.
`/islandora/search/fgs_label_t%3A(Test\-Object)`.
* Now resubmit the page and you'll notice that the browser automatically changes the the backslash to a forward slash because browsers 🤷‍♂️... this causes a fatal error to occur because it treats anything after the forward slash as a `$param`.
* Pull down the changes, run through the above test again and you'll now see that a 400 error is thrown instead.

# Interested parties
@whikloj