### PR TITLE
Make facets work with Solr 7

### DIFF
--- a/includes/luke.inc
+++ b/includes/luke.inc
@@ -131,7 +131,7 @@ function islandora_solr_get_luke($solr_url = NULL, $field = NULL, $num_terms = 0
  * Returns an array containing all fields in Luke that are sortable.
  *
  * Must be indexed and can't be multivalued.
- * @link http://archive.apache.org/dist/lucene/solr/ref-guide/ 
+ * @link http://archive.apache.org/dist/lucene/solr/ref-guide/
  * Common Query Parameters: Sort section for more info on constraints. @endlink
  *
  * @param string $solr_url
@@ -234,4 +234,75 @@ function islandora_solr_get_type_class($solr_type) {
   else {
     return FALSE;
   }
+}
+
+/**
+ * Determine the version of solr being run.
+ *
+ * @param bool $reset
+ *   Force a reset of the static version variable.
+ *
+ * @return array|bool
+ *   The version array or FALSE if can't be determined.
+ *
+ * Version array has structure:
+ *  array(
+ *    'version' => 'string of version'.
+ *    'major' => first digit (if parseable),
+ *    'minor' => second digit (if applicable),
+ *    'patch' => third digit (if applicable)
+ *  );
+ *
+ *  Only version is guaranteed to be returned on a successful request.
+ */
+function islandora_solr_get_solr_version($reset = FALSE) {
+  $version = &drupal_static(__FUNCTION__);
+  if (!isset($version) || $reset) {
+    $version = FALSE;
+    $solr_url = variable_get('islandora_solr_url', 'localhost:8080/solr');
+    if (islandora_solr_ping($solr_url)) {
+      $parts = explode('/', $solr_url);
+      while (count($parts) >= 2) {
+        // If we pass a core, we need to move up to solr root.
+        $solr_url = implode('/', $parts);
+        $admin_url = $solr_url . '/admin/info/system';
+        $admin_url = islandora_solr_check_http($admin_url);
+        // Need to set a timeout greater than the default 30 seconds as some indexes
+        // could contain a lot of fields and the Luke needs longer to respond in
+        // kind.
+        $timeout = variable_get('islandora_solr_luke_timeout', '45');
+        $admin_url = url($admin_url, array(
+          'absolute' => TRUE,
+          'timeout' => $timeout,
+          'query' => array(
+            'wt' => 'json',
+          ),
+        ));
+        $r = drupal_http_request($admin_url);
+        if ($r->code / 100 === 2) {
+          $admin_json = $r->data;
+          // Parse JSON.
+          $admin_array = json_decode($admin_json, TRUE);
+          if (isset($admin_array['lucene']['solr-spec-version'])) {
+            $v_parts = explode('.', $admin_array['lucene']['solr-spec-version']);
+            $version = array(
+              'version' => $admin_array['lucene']['solr-spec-version'],
+            );
+            if ($v_parts) {
+              $version['major'] = (int) $v_parts[0];
+            }
+            if (count($v_parts) > 1) {
+              $version['minor'] = (int) $v_parts[1];
+            }
+            if (count($v_parts) > 2) {
+              $version['patch'] = (int) $v_parts[2];
+            }
+            break;
+          }
+        }
+        array_pop($parts);
+      }
+    }
+  }
+  return $version;
 }

--- a/includes/luke.inc
+++ b/includes/luke.inc
@@ -267,9 +267,9 @@ function islandora_solr_get_solr_version($reset = FALSE) {
         $solr_url = implode('/', $parts);
         $admin_url = $solr_url . '/admin/info/system';
         $admin_url = islandora_solr_check_http($admin_url);
-        // Need to set a timeout greater than the default 30 seconds as some indexes
-        // could contain a lot of fields and the Luke needs longer to respond in
-        // kind.
+        // Need to set a timeout greater than the default 30 seconds as some
+        // indexescould contain a lot of fields and the Luke needs longer to
+        // respond in kind.
         $timeout = variable_get('islandora_solr_luke_timeout', '45');
         $admin_url = url($admin_url, array(
           'absolute' => TRUE,

--- a/includes/luke.inc
+++ b/includes/luke.inc
@@ -245,13 +245,11 @@ function islandora_solr_get_type_class($solr_type) {
  * @return array|bool
  *   The version array or FALSE if can't be determined.
  *
- * Version array has structure:
- *  array(
+ * Version array has keys:
  *    'version' => 'string of version'.
  *    'major' => first digit (if parseable),
  *    'minor' => second digit (if applicable),
  *    'patch' => third digit (if applicable)
- *  );
  *
  *  Only version is guaranteed to be returned on a successful request.
  */

--- a/includes/query_processor.inc
+++ b/includes/query_processor.inc
@@ -38,6 +38,8 @@ class IslandoraSolrQueryProcessor {
     '',
   );
 
+  private $solrVersion;
+
   /**
    * Handle deprectation of old class member gracefully.
    */
@@ -63,6 +65,25 @@ class IslandoraSolrQueryProcessor {
 
       return $this->$new_name;
     }
+  }
+
+  /**
+   * IslandoraSolrQueryProcessor constructor.
+   */
+  public function __construct() {
+    $this->solrVersion = islandora_solr_get_solr_version();
+  }
+
+  /**
+   * Solr removed Date faceting version 6.
+   *
+   * @return bool
+   *   Whether we know your Solr version and its below 6.
+   */
+  private function solrHasDateFacets() {
+    return ($this->solrVersion === FALSE
+      || (isset($this->solrVersion['major'])
+      && $this->solrVersion['major'] < 6));
   }
 
   /**
@@ -198,31 +219,62 @@ class IslandoraSolrQueryProcessor {
     }
 
     // Check for date facets.
-    $facet_dates = islandora_solr_get_range_facets();
-    if (!empty($facet_dates)) {
+    $facet_dates_ranges = islandora_solr_get_range_facets();
+    if (!empty($facet_dates_ranges)) {
       // Set range/date variables.
       $params_date_facets = array();
-      $facet_dates = array_filter($facet_dates, function($o){ islandora_solr_is_date_field($o);}, ARRAY_FILTER_USE_KEY);
-      foreach ($facet_dates as $key => $value) {
+      $facet_dates = array_filter($facet_dates_ranges, function($o){
+        return islandora_solr_is_date_field($o['solr_field']);
+      });
+      foreach ($facet_dates_ranges as $key => $value) {
         $field = $value['solr_field'];
         $start = $value['solr_field_settings']['range_facet_start'];
         $end = $value['solr_field_settings']['range_facet_end'];
         $gap = $value['solr_field_settings']['range_facet_gap'];
-        // Add date and range facet to support both old and new facets.
-        $params_date_facets["facet.date"][] = $field;
-        $params_date_facets["facet.range"][] = $field;
-        // Custom field settings.
-        if ($start) {
+        if ($this->solrHasDateFacets()) {
+          // < Solr 6 or we don't know.
+          $params_date_facets["facet.date"][] = $field;
           $params_date_facets["f.{$field}.facet.date.start"] = $start;
-          $params_date_facets["f.{$field}.facet.range.start"] = $start;
+          // Custom field settings.
+          if ($start) {
+            $params_date_facets["f.{$field}.facet.date.start"] = $start;
+          }
+          if ($end) {
+            $params_date_facets["f.{$field}.facet.date.end"] = $end;
+          }
+          if ($gap) {
+            $params_date_facets["f.{$field}.facet.date.gap"] = $gap;
+          }
+          // Default settings.
+          $params_date_facets["facet.date.start"] = 'NOW/YEAR-20YEARS';
+          $params_date_facets["facet.date.end"] = 'NOW';
+          $params_date_facets["facet.date.gap"] = '+1YEAR';
         }
-        if ($end) {
-          $params_date_facets["f.{$field}.facet.date.end"] = $end;
-          $params_date_facets["f.{$field}.facet.range.end"] = $end;
-        }
-        if ($gap) {
-          $params_date_facets["f.{$field}.facet.date.gap"] = $gap;
-          $params_date_facets["f.{$field}.facet.range.gap"] = $gap;
+        else {
+          // No more date facets.
+          $params_date_facets["facet.range"][] = $field;
+          if (in_array($field, $facet_dates)) {
+            // Use date defaults for date solr fields.
+            // TODO: Maybe these should be removed and left to the config form.
+            if (!$start) {
+              $start = 'NOW/YEAR-20YEARS';
+            }
+            if (!$end) {
+              $end = 'NOW';
+            }
+            if (!$gap) {
+              $gap = '+1YEAR';
+            }
+          }
+          if ($start) {
+            $params_date_facets["f.{$field}.facet.range.start"] = $start;
+          }
+          if ($end) {
+            $params_date_facets["f.{$field}.facet.range.end"] = $end;
+          }
+          if ($gap) {
+            $params_date_facets["f.{$field}.facet.range.gap"] = $gap;
+          }
         }
         // When the range slider is enabled we always want to return empty
         // values.
@@ -233,10 +285,6 @@ class IslandoraSolrQueryProcessor {
         $pos = array_search($field, $params_array['facet.field']);
         unset($params_array['facet.field'][$pos]);
       }
-      // Default settings.
-      $params_date_facets["facet.date.start"] = 'NOW/YEAR-20YEARS';
-      $params_date_facets["facet.date.end"] = 'NOW';
-      $params_date_facets["facet.date.gap"] = '+1YEAR';
 
       $params_array = array_merge($params_array, $params_date_facets);
     }

--- a/includes/query_processor.inc
+++ b/includes/query_processor.inc
@@ -209,15 +209,19 @@ class IslandoraSolrQueryProcessor {
         $gap = $value['solr_field_settings']['range_facet_gap'];
         // Add date facet.
         $params_date_facets["facet.date"][] = $field;
+        $params_date_facets["facet.range"][] = $field;
         // Custom field settings.
         if ($start) {
           $params_date_facets["f.{$field}.facet.date.start"] = $start;
+          $params_date_facets["f.{$field}.facet.range.start"] = $start;
         }
         if ($end) {
           $params_date_facets["f.{$field}.facet.date.end"] = $end;
+          $params_date_facets["f.{$field}.facet.range.end"] = $end;
         }
         if ($gap) {
           $params_date_facets["f.{$field}.facet.date.gap"] = $gap;
+          $params_date_facets["f.{$field}.facet.range.gap"] = $gap;
         }
         // When the range slider is enabled we always want to return empty
         // values.
@@ -232,6 +236,9 @@ class IslandoraSolrQueryProcessor {
       $params_date_facets["facet.date.start"] = 'NOW/YEAR-20YEARS';
       $params_date_facets["facet.date.end"] = 'NOW';
       $params_date_facets["facet.date.gap"] = '+1YEAR';
+      $params_date_facets["facet.range.start"] = 'NOW/YEAR-20YEARS';
+      $params_date_facets["facet.range.end"] = 'NOW';
+      $params_date_facets["facet.range.gap"] = '+1YEAR';
 
       $params_array = array_merge($params_array, $params_date_facets);
     }
@@ -240,7 +247,7 @@ class IslandoraSolrQueryProcessor {
     $default_sort = (variable_get('islandora_solr_facet_max_limit', '20') <= 0 ? 'index' : 'count');
 
     $facet_sort_array = array();
-    foreach (array_merge($facet_array, $facet_dates) as $key => $value) {
+    foreach ($facet_array as $key => $value) {
       if (isset($value['solr_field_settings']['sort_by']) && $value['solr_field_settings']['sort_by'] != $default_sort) {
         // If the sort doesn't match default then specify it in the parameters.
         $facet_sort_array["f.{$key}.facet.sort"] = check_plain($value['solr_field_settings']['sort_by']);

--- a/includes/query_processor.inc
+++ b/includes/query_processor.inc
@@ -172,7 +172,7 @@ class IslandoraSolrQueryProcessor {
     }
 
     // Get pager variable.
-    $start_page = isset($_GET['page']) ? $_GET['page'] : 0;
+    $start_page = isset($_GET['page']) ? $_GET['page'] : isset($params['start']) ? $params['start'] : 0;
 
     // Set results limit.
     $this->solrLimit = isset($this->internalSolrParams['limit']) ? $this->internalSolrParams['limit'] : variable_get('islandora_solr_num_of_results', 20);
@@ -202,6 +202,7 @@ class IslandoraSolrQueryProcessor {
     if (!empty($facet_dates)) {
       // Set range/date variables.
       $params_date_facets = array();
+      $facet_dates = array_filter($facet_dates, function($o){ islandora_solr_is_date_field($o);}, ARRAY_FILTER_USE_KEY);
       foreach ($facet_dates as $key => $value) {
         $field = $value['solr_field'];
         $start = $value['solr_field_settings']['range_facet_start'];
@@ -236,9 +237,6 @@ class IslandoraSolrQueryProcessor {
       $params_date_facets["facet.date.start"] = 'NOW/YEAR-20YEARS';
       $params_date_facets["facet.date.end"] = 'NOW';
       $params_date_facets["facet.date.gap"] = '+1YEAR';
-      $params_date_facets["facet.range.start"] = 'NOW/YEAR-20YEARS';
-      $params_date_facets["facet.range.end"] = 'NOW';
-      $params_date_facets["facet.range.gap"] = '+1YEAR';
 
       $params_array = array_merge($params_array, $params_date_facets);
     }

--- a/includes/query_processor.inc
+++ b/includes/query_processor.inc
@@ -207,7 +207,7 @@ class IslandoraSolrQueryProcessor {
         $start = $value['solr_field_settings']['range_facet_start'];
         $end = $value['solr_field_settings']['range_facet_end'];
         $gap = $value['solr_field_settings']['range_facet_gap'];
-        // Add date facet and range facet to support old date facets and new range facets.
+        // Add date and range facet to support both old and new facets.
         $params_date_facets["facet.date"][] = $field;
         $params_date_facets["facet.range"][] = $field;
         // Custom field settings.

--- a/includes/query_processor.inc
+++ b/includes/query_processor.inc
@@ -207,7 +207,7 @@ class IslandoraSolrQueryProcessor {
         $start = $value['solr_field_settings']['range_facet_start'];
         $end = $value['solr_field_settings']['range_facet_end'];
         $gap = $value['solr_field_settings']['range_facet_gap'];
-        // Add date facet.
+        // Add date facet and range facet to support old date facets and new range facets.
         $params_date_facets["facet.date"][] = $field;
         $params_date_facets["facet.range"][] = $field;
         // Custom field settings.

--- a/includes/query_processor.inc
+++ b/includes/query_processor.inc
@@ -223,7 +223,7 @@ class IslandoraSolrQueryProcessor {
     if (!empty($facet_dates_ranges)) {
       // Set range/date variables.
       $params_date_facets = array();
-      $facet_dates = array_filter($facet_dates_ranges, function($o){
+      $facet_dates = array_filter($facet_dates_ranges, function($o) {
         return islandora_solr_is_date_field($o['solr_field']);
       });
       foreach ($facet_dates_ranges as $key => $value) {

--- a/includes/query_processor.inc
+++ b/includes/query_processor.inc
@@ -38,7 +38,7 @@ class IslandoraSolrQueryProcessor {
     '',
   );
 
-  private $solrVersion;
+  protected $solrVersion;
 
   /**
    * Handle deprectation of old class member gracefully.
@@ -80,7 +80,7 @@ class IslandoraSolrQueryProcessor {
    * @return bool
    *   Whether we know your Solr version and its below 6.
    */
-  private function solrHasDateFacets() {
+  protected function solrHasDateFacets() {
     return ($this->solrVersion === FALSE
       || (isset($this->solrVersion['major'])
       && $this->solrVersion['major'] < 6));

--- a/includes/query_processor.inc
+++ b/includes/query_processor.inc
@@ -193,7 +193,7 @@ class IslandoraSolrQueryProcessor {
     }
 
     // Get pager variable.
-    $start_page = isset($_GET['page']) ? $_GET['page'] : isset($params['start']) ? $params['start'] : 0;
+    $start_page = isset($_GET['page']) ? $_GET['page'] : (isset($params['start']) ? $params['start'] : 0);
 
     // Set results limit.
     $this->solrLimit = isset($this->internalSolrParams['limit']) ? $this->internalSolrParams['limit'] : variable_get('islandora_solr_num_of_results', 20);

--- a/includes/results.inc
+++ b/includes/results.inc
@@ -669,6 +669,14 @@ class IslandoraSolrFacets {
   public $title = NULL;
   public $content = NULL;
 
+  /**
+   * Is this a range on a Solr date field?
+   *
+   * @var bool
+   *   Whether it is.
+   */
+  private $date_range = FALSE;
+
 
   // @codingStandardsIgnoreEnd
 
@@ -769,6 +777,7 @@ class IslandoraSolrFacets {
     }
     if (array_key_exists($facet_field, self::$facet_ranges)) {
       $this->facet_type = 'facet_ranges';
+      $this->date_range = islandora_solr_is_date_field($facet_field);
     }
   }
 
@@ -803,7 +812,8 @@ class IslandoraSolrFacets {
     if ($facet_type == 'facet_fields') {
       $this->processFacetFields();
     }
-    if ($facet_type == 'facet_dates') {
+    if ($facet_type == 'facet_dates'
+      || ($facet_type == 'facet_ranges' && $this->date_range)) {
       $this->processFacetDates();
     }
     if ($facet_type == 'facet_ranges') {
@@ -867,7 +877,7 @@ class IslandoraSolrFacets {
    * to handle differences between date and range fields.
    */
   public function processFacetRanges() {
-    $this->processFacetDates();
+
   }
 
   /**

--- a/includes/results.inc
+++ b/includes/results.inc
@@ -871,10 +871,7 @@ class IslandoraSolrFacets {
   }
 
   /**
-   * Process facet ranges.
-   *
-   * Based on the existing implementation for date fields, but modified in place
-   * to handle differences between date and range fields.
+   * Not in place yet.
    */
   public function processFacetRanges() {
 

--- a/includes/results.inc
+++ b/includes/results.inc
@@ -675,7 +675,7 @@ class IslandoraSolrFacets {
    * @var bool
    *   Whether it is.
    */
-  private $date_range = FALSE;
+  protected $date_range = FALSE;
 
 
   // @codingStandardsIgnoreEnd

--- a/includes/results.inc
+++ b/includes/results.inc
@@ -699,7 +699,6 @@ class IslandoraSolrFacets {
     self::$facet_fields = isset($islandora_solr_query->islandoraSolrResult) ? $islandora_solr_query->islandoraSolrResult['facet_counts']['facet_fields'] : array();
     // XXX: isset() checking, as newer Solrs (7) won't return a value.
     self::$facet_dates = isset($islandora_solr_query->islandoraSolrResult['facet_counts']['facet_dates']) ? $islandora_solr_query->islandoraSolrResult['facet_counts']['facet_dates'] : array();
-    // Not in place yet.
     // XXX: isset() checking, as older Solrs (before 3.1) won't return a value.
     self::$facet_ranges = isset($islandora_solr_query->islandoraSolrResult['facet_counts']['facet_ranges']) ?
       $islandora_solr_query->islandoraSolrResult['facet_counts']['facet_ranges'] :

--- a/includes/results.inc
+++ b/includes/results.inc
@@ -871,6 +871,8 @@ class IslandoraSolrFacets {
   }
 
   /**
+   * Process facet ranges.
+   *
    * Not in place yet.
    */
   public function processFacetRanges() {

--- a/includes/results.inc
+++ b/includes/results.inc
@@ -697,7 +697,8 @@ class IslandoraSolrFacets {
   public static function init($islandora_solr_query) {
     self::$islandoraSolrQuery = $islandora_solr_query;
     self::$facet_fields = isset($islandora_solr_query->islandoraSolrResult) ? $islandora_solr_query->islandoraSolrResult['facet_counts']['facet_fields'] : array();
-    self::$facet_dates = isset($islandora_solr_query->islandoraSolrResult) ? $islandora_solr_query->islandoraSolrResult['facet_counts']['facet_dates'] : array();
+    // XXX: isset() checking, as newer Solrs (7) won't return a value.
+    self::$facet_dates = isset($islandora_solr_query->islandoraSolrResult['facet_counts']['facet_dates']) ? $islandora_solr_query->islandoraSolrResult['facet_counts']['facet_dates'] : array();
     // Not in place yet.
     // XXX: isset() checking, as older Solrs (before 3.1) won't return a value.
     self::$facet_ranges = isset($islandora_solr_query->islandoraSolrResult['facet_counts']['facet_ranges']) ?
@@ -863,10 +864,11 @@ class IslandoraSolrFacets {
   /**
    * Process facet ranges.
    *
-   * Not in place yet.
+   * Based on the existing implementation for date fields, but modified in place
+   * to handle differences between date and range fields.
    */
   public function processFacetRanges() {
-
+    $this->processFacetDates();
   }
 
   /**
@@ -913,6 +915,10 @@ class IslandoraSolrFacets {
     $facet_field = $this->facet_field;
     $results = $this->results;
     $format = $this->getDateFormat();
+    if ($this->facet_type == 'facet_ranges') {
+      $results = array_merge($results, $results['counts']);
+      unset($results['counts']);
+    }
     $date_results = array();
     // Render date facet fields.
     foreach ($results as $bucket => $count) {
@@ -927,7 +933,7 @@ class IslandoraSolrFacets {
       $field_keys = array_keys($results);
       $field_key = array_search($bucket, $field_keys);
       $field_key++;
-      $bucket_next = (!in_array($field_keys[$field_key], self::$exclude_range_values)) ? $field_keys[$field_key] : $results['end'];
+      $bucket_next = (isset($field_keys[$field_key]) && !in_array($field_keys[$field_key], self::$exclude_range_values) ? $field_keys[$field_key] : $results['end']);
       // Set date range filter for facet URL.
       $item['filter'] = $facet_field . ':[' . $bucket . ' TO ' . $bucket_next . ']';
       // Set formatted value for facet link.
@@ -1136,6 +1142,9 @@ class IslandoraSolrFacets {
     $results_end = $results['end'];
     foreach (self::$exclude_range_values as $exclude) {
       unset($results[$exclude]);
+    }
+    if ($this->facet_type == 'facet_ranges' && isset($results['counts'])) {
+      $results = $results['counts'];
     }
 
     // Strip empty buckets top and bottom when no date range filters are set.

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -635,6 +635,7 @@ function islandora_solr_is_date_field($solr_field) {
     'org.apache.solr.schema.DateField',
     'org.apache.solr.schema.TrieDateField',
     'org.apache.solr.schema.DatePointField',
+    'org.apache.solr.schema.DateRangeField',
   );
   return islandora_solr_is_typed_field($solr_field, $date_types);
 }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -634,6 +634,7 @@ function islandora_solr_is_date_field($solr_field) {
   $date_types = array(
     'org.apache.solr.schema.DateField',
     'org.apache.solr.schema.TrieDateField',
+    'org.apache.solr.schema.DatePointField',
   );
   return islandora_solr_is_typed_field($solr_field, $date_types);
 }


### PR DESCRIPTION
**JIRA Ticket**: 
 * https://jira.duraspace.org/browse/ISLANDORA-2201
 * https://jira.duraspace.org/browse/ISLANDORA-2271

# What does this Pull Request do?

We (U of Manitoba) want to upgrade the supporting software for Islandora, specifically Solr. We are trying with Solr 7 and found that date faceting has been removed. Instead we must use Range faceting only.

This PR adds in support for range facets. The framework was there so I just tried to fill in the bits and pieces.

# What's new?
By default I pass `facet.date` parameters also as `facet.range` as I could not see how to tell whether a facet was a date or range type in the query_processor. It did not seem to have a noticeable effect.

Inside I just adjusted the facet results, to account for the differences but re-use most of the code.

I am assuming we will be supporting all versions of Solr from 3 to 100 so this probably needs a lot of testing, but I am also not convinced most people will upgrade their Solr so maybe the primary focus is to ensure the current functionality is maintained.

# How should this be tested?

This is tough, I could not just point FedoraGSearch at Solr 7 as it now throws a stacktrace.
```
dk.defxws.fedoragsearch.server.errors.GenericSearchException: Mon Jul 09 20:17:08 UTC 2018 updateIndex NumberFormatException numFound=nseHeader
{  "responseHeader":{    "status":0,    "QTime":0,    "params":{      "q":"*:*",      "rows":"0"}},  "response":{"numFound":21,"start":0,"docs":[]  }}; nested exception is: 
	java.lang.NumberFormatException: For input string: "nseHeader"
	at dk.defxws.fgssolrremote.OperationsImpl.updateIndex(OperationsImpl.java:118)
	at dk.defxws.fedoragsearch.server.GenericOperationsImpl.updateIndex(GenericOperationsImpl.java:556)
	at dk.defxws.fedoragsearch.server.RESTImpl.updateIndex(RESTImpl.java:313)
	at dk.defxws.fedoragsearch.server.RESTImpl.doGet(RESTImpl.java:149)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:620)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:727)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:303)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:208)
	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:52)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:241)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:208)
	at org.fcrepo.server.security.servletfilters.FilterSetup.doFilter(FilterSetup.java:247)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:241)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:208)
	at org.fcrepo.server.security.servletfilters.FilterSetup.doFilter(FilterSetup.java:247)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:241)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:208)
	at org.fcrepo.server.security.servletfilters.FilterSetup.doFilter(FilterSetup.java:247)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:241)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:208)
	at org.fcrepo.server.security.servletfilters.FilterSetup.doFilter(FilterSetup.java:247)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:241)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:208)
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:220)
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:122)
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:501)
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:171)
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:103)
	at org.apache.catalina.valves.AccessLogValve.invoke(AccessLogValve.java:950)
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:116)
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:408)
	at org.apache.coyote.http11.AbstractHttp11Processor.process(AbstractHttp11Processor.java:1070)
	at org.apache.coyote.AbstractProtocol$AbstractConnectionHandler.process(AbstractProtocol.java:611)
	at org.apache.tomcat.util.net.JIoEndpoint$SocketProcessor.run(JIoEndpoint.java:314)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.NumberFormatException: For input string: "nseHeader"
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.lang.Integer.parseInt(Integer.java:580)
	at java.lang.Integer.parseInt(Integer.java:615)
	at dk.defxws.fgssolrremote.OperationsImpl.updateIndex(OperationsImpl.java:116)
	... 37 more
```

 So I had to use my own indexer to get stuff into Solr, I didn't spend a lot of time debugging GSearch though so I might have missed a simple fix.

Anyways, my major concern is that this doesn't harm everyone else as I imagine the number of people upgrading their Solr is in the minority.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

Example:
* Does this change require documentation to be updated? Probably, though from the user's side nothing has changed
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@Islandora/7-x-1-x-committers @DiegoPino @giancarlobi 
