### PR TITLE
Translate current query filters

### DIFF
--- a/includes/results.inc
+++ b/includes/results.inc
@@ -18,6 +18,7 @@ class IslandoraSolrResults {
   public $islandoraSolrQueryProcessor;
   public $rangeFacets = array();
   public $dateFormatFacets = array();
+  private $facetFieldSettings = NULL;
 
   /**
    * Constructor.
@@ -27,6 +28,20 @@ class IslandoraSolrResults {
     $this->rangeFacets = islandora_solr_get_range_facets();
     $this->dateFormatFacets = islandora_solr_get_date_format_facets();
   }
+
+  /**
+   * Get the facet field settings.
+   *
+   * @return array
+   *   The array of facet field settings configured.
+   */
+  public function getFacetFieldSettings() {
+    if (is_null($this->facetFieldSettings)) {
+      $this->facetFieldSettings = islandora_solr_get_fields('facet_fields', TRUE, FALSE, TRUE);
+    }
+    return $this->facetFieldSettings;
+  }
+
 
   /**
    * Output the main body of the search results.
@@ -550,28 +565,14 @@ class IslandoraSolrResults {
         $format = $this->dateFormatFacets[$solr_field]['solr_field_settings']['date_facet_format'];
         $filter_split[1] = format_date(strtotime(stripslashes($filter_split[1])), 'custom', $format);
       }
-      $facet_fields_settings = islandora_solr_get_fields('facet_fields', TRUE, FALSE, TRUE);
-      $filter_string = str_replace('info:fedora/', '', stripslashes($filter_split[1]));
+      $facet_fields_settings = $this->getFacetFieldSettings();
+      $filter_string = $filter_split[1];
       if (isset($facet_fields_settings[$solr_field]['solr_field_settings']['pid_object_label']) && $facet_fields_settings[$solr_field]['solr_field_settings']['pid_object_label'] == 1) {
-        $qp = new IslandoraSolrQueryProcessor();
-        $qp->buildQuery(format_string('PID:(!pids)', array(
-          '!pids' => $filter_string,
-        )));
-        $label_field = variable_get('islandora_solr_object_label_field', 'fgs_label_s');
-        $qp->solrParams['facet'] = 'false';
-        $qp->solrParams['fl'] = "PID, $label_field";
-        $qp->solrLimit = 1;
-        $qp->executeQuery(FALSE, TRUE);
-        if ($qp->islandoraSolrResult['response']['numFound'] > 0) {
-          foreach ($qp->islandoraSolrResult['response']['objects'] as $doc) {
-            $filter_string = $doc['object_label'];
-          }
-        }
-        else if ($object = islandora_object_load($filter_string)) {
+        $filter_string = str_replace('info:fedora/', '', stripslashes($filter_string));
+        if ($object = islandora_object_load($filter_string)) {
           $filter_string = $object->label;
         }
       }
-
     }
     return stripslashes($filter_string);
   }

--- a/includes/results.inc
+++ b/includes/results.inc
@@ -3,11 +3,12 @@
 /**
  * @file
  * Contains methods to create rendered Solr displays from raw Solr results.
+ *
  * Depends on Apache_Solr_Php client.
  */
 
 /**
- * Islandora Solr Results
+ * Islandora Solr Results.
  */
 class IslandoraSolrResults {
 
@@ -18,7 +19,7 @@ class IslandoraSolrResults {
   public $islandoraSolrQueryProcessor;
   public $rangeFacets = array();
   public $dateFormatFacets = array();
-  private $facetFieldSettings = NULL;
+  public $facetFieldSettings = array();
 
   /**
    * Constructor.
@@ -28,20 +29,6 @@ class IslandoraSolrResults {
     $this->rangeFacets = islandora_solr_get_range_facets();
     $this->dateFormatFacets = islandora_solr_get_date_format_facets();
   }
-
-  /**
-   * Get the facet field settings.
-   *
-   * @return array
-   *   The array of facet field settings configured.
-   */
-  public function getFacetFieldSettings() {
-    if (is_null($this->facetFieldSettings)) {
-      $this->facetFieldSettings = islandora_solr_get_fields('facet_fields', TRUE, FALSE, TRUE);
-    }
-    return $this->facetFieldSettings;
-  }
-
 
   /**
    * Output the main body of the search results.
@@ -190,7 +177,6 @@ class IslandoraSolrResults {
     // Return themed search results.
     return theme('islandora_solr', array('results' => $object_results, 'elements' => $elements));
   }
-
 
   /**
    * Displays elements of the current solr query.
@@ -513,7 +499,7 @@ class IslandoraSolrResults {
    * @param string $filter
    *   The passed in filter.
    * @param object $islandora_solr_query
-   *   The current Solr Query
+   *   The current Solr Query.
    *
    * @return string
    *   The formatted filter string for breadcrumbs and active query.
@@ -565,12 +551,14 @@ class IslandoraSolrResults {
         $format = $this->dateFormatFacets[$solr_field]['solr_field_settings']['date_facet_format'];
         $filter_split[1] = format_date(strtotime(stripslashes($filter_split[1])), 'custom', $format);
       }
-      $facet_fields_settings = $this->getFacetFieldSettings();
+      $facet_fields_settings = $this->facetFieldSettings;
       $filter_string = $filter_split[1];
       if (isset($facet_fields_settings[$solr_field]['solr_field_settings']['pid_object_label']) && $facet_fields_settings[$solr_field]['solr_field_settings']['pid_object_label'] == 1) {
-        $filter_string = str_replace('info:fedora/', '', stripslashes($filter_string));
-        if ($object = islandora_object_load($filter_string)) {
-          $filter_string = $object->label;
+        $pid = str_replace('info:fedora/', '', stripslashes($filter_string));
+        if ($object = islandora_object_load($pid)) {
+          if (islandora_object_access(ISLANDORA_VIEW_OBJECTS, $object)) {
+            $filter_string = $object->label;
+          }
         }
       }
     }
@@ -647,7 +635,9 @@ class IslandoraSolrResults {
    */
   public function prepFieldSubstitutions() {
 
-    $this->facetFieldArray = islandora_solr_get_fields('facet_fields');
+    $facet_fields =  $this->facetFieldSettings = islandora_solr_get_fields('facet_fields', TRUE, FALSE, TRUE);
+
+    $this->facetFieldArray = _islandora_solr_simplify_fields($facet_fields);
 
     $this->searchFieldArray = islandora_solr_get_fields('search_fields');
 

--- a/includes/results.inc
+++ b/includes/results.inc
@@ -550,7 +550,28 @@ class IslandoraSolrResults {
         $format = $this->dateFormatFacets[$solr_field]['solr_field_settings']['date_facet_format'];
         $filter_split[1] = format_date(strtotime(stripslashes($filter_split[1])), 'custom', $format);
       }
-      $filter_string = $filter_split[1];
+      $facet_fields_settings = islandora_solr_get_fields('facet_fields', TRUE, FALSE, TRUE);
+      $filter_string = str_replace('info:fedora/', '', stripslashes($filter_split[1]));
+      if (isset($facet_fields_settings[$solr_field]['solr_field_settings']['pid_object_label']) && $facet_fields_settings[$solr_field]['solr_field_settings']['pid_object_label'] == 1) {
+        $qp = new IslandoraSolrQueryProcessor();
+        $qp->buildQuery(format_string('PID:(!pids)', array(
+          '!pids' => $filter_string,
+        )));
+        $label_field = variable_get('islandora_solr_object_label_field', 'fgs_label_s');
+        $qp->solrParams['facet'] = 'false';
+        $qp->solrParams['fl'] = "PID, $label_field";
+        $qp->solrLimit = 1;
+        $qp->executeQuery(FALSE, TRUE);
+        if ($qp->islandoraSolrResult['response']['numFound'] > 0) {
+          foreach ($qp->islandoraSolrResult['response']['objects'] as $doc) {
+            $filter_string = $doc['object_label'];
+          }
+        }
+        else if ($object = islandora_object_load($filter_string)) {
+          $filter_string = $object->label;
+        }
+      }
+
     }
     return stripslashes($filter_string);
   }

--- a/includes/results.inc
+++ b/includes/results.inc
@@ -635,7 +635,7 @@ class IslandoraSolrResults {
    */
   public function prepFieldSubstitutions() {
 
-    $facet_fields =  $this->facetFieldSettings = islandora_solr_get_fields('facet_fields', TRUE, FALSE, TRUE);
+    $facet_fields = $this->facetFieldSettings = islandora_solr_get_fields('facet_fields', TRUE, FALSE, TRUE);
 
     $this->facetFieldArray = _islandora_solr_simplify_fields($facet_fields);
 
@@ -645,6 +645,7 @@ class IslandoraSolrResults {
 
     $this->allSubsArray = array_merge($this->facetFieldArray, $this->searchFieldArray, $this->resultFieldArray);
   }
+
 }
 
 /**


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2288

# What does this Pull Request do?

If you choose the "Replace PID with Object Label" for a facet, this does not change the filter section of the Islandora Query block.

# What's new?

Change to formatFilter() to check if the "Replace PID with Object Label" setting has been set and if so tries to convert the PID to a label using Solr or loading the object and using the `$object->label`.

# How should this be tested?

Add some facet that displays PIDs, then also add the Islandora Query block (see example screenshots on linked ticket.)

Do a search and the click the converted facet. See that the Filter section of the Islandora Query block is not still converted.

Also the breadcrumbs are wrong.

Pull in this PR. Reload the results page and 

![translate_current_query3](https://user-images.githubusercontent.com/2857697/44039502-d2572e5e-9ede-11e8-8e57-acac1aed3dbd.png)

# Additional Notes:

Example:
* Does this change require documentation to be updated? Unsure
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? Unsure

# Interested parties
@Islandora/7-x-1-x-committers @lucasvanschaik @janjouketjalsma
