### PR TITLE
Add a compound backend

### DIFF
--- a/includes/compound_backend.inc
+++ b/includes/compound_backend.inc
@@ -85,7 +85,7 @@ function islandora_solr_compound_object_query($pid) {
   $solr_build->solrParams['facet'] = $solr_build->solrParams['hl'] = 'false';
   $solr_build->solrParams = islandora_solr_clean_compound_filters($solr_build->solrParams);
 
-  // Loop in case there are lots
+  // Loop in case there are lots.
   do {
     $start += 1;
     $solr_build->solrStart = $start * $rows;
@@ -105,7 +105,7 @@ function islandora_solr_compound_object_query($pid) {
   } while ($total > (($start * $rows) + $rows));
 
   if (count($constituents) > 0) {
-   $sort = function($a, $b) use($sequence_pattern) {
+    $sort = function($a, $b) use($sequence_pattern) {
       $a = $a['solr_doc'][$sequence_pattern];
       if (is_array($a)) {
         $a = reset($a);

--- a/includes/compound_backend.inc
+++ b/includes/compound_backend.inc
@@ -1,0 +1,147 @@
+<?php
+/**
+ * @file
+ * Compound backend stuff.
+ */
+
+
+/**
+ * Admin options.
+ *
+ * @param array $form
+ *   The form.
+ * @param array $form_state
+ *   The form state.
+ *
+ * @return array
+ *   The updated form.
+ */
+function islandora_solr_compound_backend_admin_form(array $form, array $form_state) {
+  $form = array();
+  $form['islandora_solr_compound_relationship_field'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Solr compound relationship field'),
+    '#description' => t('Solr field containing the compound relationship. Defaults to RELS_EXT_isConstituentOf_uri_ms'),
+    '#default_value' => variable_get('islandora_solr_compound_relationship_field', 'RELS_EXT_isConstituentOf_uri_ms'),
+    '#autocomplete_path' => 'islandora_solr/autocomplete_luke',
+  );
+  $form['islandora_solr_compound_sequence_pattern'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Solr compound sequence pattern'),
+    '#description' => t('Compound sequences are stored with a unique relationship, if you index these in Solr provide the field name with %PID% in place of the actual escaped pid to use the SOLR Compound Member Query. Defaults to RELS_EXT_isSequenceNumberOf%PID%_literal_ms'),
+    '#default_value' => variable_get('islandora_solr_compound_sequence_pattern', 'RELS_EXT_isSequenceNumberOf%PID%_literal_ms'),
+  );
+  return system_settings_form($form);
+}
+
+/**
+ * Implements hook_form_validate().
+ */
+function islandora_solr_compound_backend_admin_form_validate(array $form, array &$form_state) {
+  $default_pattern = variable_get('islandora_solr_compound_sequence_pattern', 'RELS_EXT_isSequenceNumberOf%PID%_literal_ms');
+  if (isset($form_state['values']['islandora_solr_compound_sequence_pattern'])
+    && $form_state['values']['islandora_solr_compound_sequence_pattern'] != $default_pattern) {
+    if (strpos($form_state['values']['islandora_solr_compound_sequence_pattern'], '%PID%') === FALSE) {
+      form_set_error('islandora_solr_compound_sequence_pattern',
+        t('Your pattern MUST contain %PID% where the converted PID will appear.'));
+    }
+  }
+}
+
+/**
+ * Implements callback_islandora_compound_object_query_backends().
+ */
+function islandora_solr_compound_object_query($pid) {
+  module_load_include('inc', 'islandora_solr', 'includes/breadcrumbs');
+
+  $solr_build = new IslandoraSolrQueryProcessor();
+  $rows = 1000;
+
+  $relationship = variable_get('islandora_solr_compound_relationship_field', 'RELS_EXT_isConstituentOf_uri_ms');
+  $sequence_pattern = variable_get('islandora_solr_compound_sequence_pattern', 'RELS_EXT_isSequenceNumberOf%PID%_literal_ms');
+  $sequence_pattern = str_replace('%PID%', str_replace(':', '_', $pid), $sequence_pattern);
+
+  $query = format_string('!field:("!pid"+OR+"info:fedora/!pid")', array(
+    '!field' => $relationship,
+    '!pid' => $pid,
+  ));
+  $params = array(
+    'limit' => $rows,
+    'rows' => $rows,
+    'fl' => format_string('PID, !seq', array(
+      '!seq' => $sequence_pattern,
+    )),
+  );
+  // Page to start on.
+  $start = -1;
+  // Total results holder.
+  $total = NULL;
+  // For cumulative storage of constituents.
+  $constituents = array();
+  // Final output.
+  $output = array();
+
+  $solr_build->buildQuery($query, $params);
+  $solr_build->solrParams['facet'] = $solr_build->solrParams['hl'] = 'false';
+  $solr_build->solrParams = islandora_solr_clean_compound_filters($solr_build->solrParams);
+
+  // Loop in case there are lots
+  do {
+    $start += 1;
+    $solr_build->solrStart = $start * $rows;
+    $solr_build->solrLimit = $rows;
+    try {
+      $solr_build->executeQuery(FALSE);
+      $results = (array) $solr_build->islandoraSolrResult['response']['objects'];
+      $constituents = array_merge($constituents, $results);
+    }
+    catch (Exception $e) {
+      drupal_set_message(check_plain(t('Error searching Solr index')) . ' ' . $e->getMessage(), 'error', FALSE);
+      break;
+    }
+    if (is_null($total) && isset($solr_build->islandoraSolrResult['response']['numFound'])) {
+      $total = $solr_build->islandoraSolrResult['response']['numFound'];
+    }
+  } while ($total > (($start * $rows) + $rows));
+
+  if (count($constituents) > 0) {
+   $sort = function($a, $b) use($sequence_pattern) {
+      $a = $a['solr_doc'][$sequence_pattern];
+      if (is_array($a)) {
+        $a = reset($a);
+      }
+      $a = intval($a);
+      $b = $b['solr_doc'][$sequence_pattern];
+      if (is_array($b)) {
+        $b = reset($b);
+      }
+      $b = intval($b);
+
+      if ($a === $b) {
+        return 0;
+      }
+      if (empty($a)) {
+        return 1;
+      }
+      if (empty($b)) {
+        return -1;
+      }
+      return $a - $b;
+    };
+    uasort($constituents, $sort);
+
+    foreach ($constituents as $result) {
+      $sequence = $result['solr_doc'][$sequence_pattern];
+      if (is_array($sequence)) {
+        $sequence = reset($sequence);
+      }
+      $output[$result['PID']] = array(
+        'pid' => $result['PID'],
+        'title' => $result['object_label'],
+        'seq' => $sequence,
+      );
+    }
+  }
+
+  return $output;
+}

--- a/islandora_solr.install
+++ b/islandora_solr.install
@@ -64,6 +64,8 @@ function islandora_solr_uninstall() {
     'islandora_solr_breadcrumbs_add_collection_query',
     'islandora_solr_simple_search_label_visibility',
     'islandora_solr_simple_search_label_title',
+    'islandora_solr_compound_relationship_field',
+    'islandora_solr_compound_sequence_pattern',
   ));
   array_walk($variables, 'variable_del');
 }

--- a/islandora_solr.module
+++ b/islandora_solr.module
@@ -99,6 +99,17 @@ function islandora_solr_menu() {
     'file' => 'includes/admin.inc',
     'type' => MENU_CALLBACK,
   );
+  if (module_exists('islandora_compound_object')) {
+    $items['admin/islandora/solution_pack_config/compound_object/solr'] = array(
+      'title' => 'Solr Backend',
+      'description' => 'Settings form for compound object backend',
+      'page callback' => 'drupal_get_form',
+      'page arguments' => array('islandora_solr_compound_backend_admin_form'),
+      'access arguments' => array('administer compound relationships'),
+      'file' => 'includes/compound_backend.inc',
+      'type' => MENU_LOCAL_TASK,
+    );
+  }
   return $items;
 }
 
@@ -496,6 +507,22 @@ function islandora_solr_islandora_basic_collection_query_backends() {
       'title' => t('Solr'),
       'callable' => 'islandora_solr_islandora_basic_collection_backend_callable',
       'file' => "$module_path/includes/utilities.inc",
+    ),
+  );
+}
+
+/**
+ * Implements hook_islandora_compound_object_query_backends().
+ */
+function islandora_solr_islandora_compound_object_query_backends() {
+  $module_path = drupal_get_path('module', 'islandora_solr');
+  return array(
+    'islandora_solr_compound_query_backend' => array(
+      'title' => t('SOLR - Does a Solr query with filters. Configure fields on the <a href="@solr">Solr Backend</a> tab.',
+        array('@solr' => url('admin/islandora/solution_pack_config/compound_object/solr'))
+      ),
+      'callable' => 'islandora_solr_compound_object_query',
+      'file' => "$module_path/includes/compound_backend.inc",
     ),
   );
 }


### PR DESCRIPTION
Validate input and cleanup variables on uninstall

**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2272

Depends on: https://github.com/Islandora/islandora_solution_pack_compound/pull/149

# What does this Pull Request do?

Adds a Solr based backed for finding compound constituent parts.

# What's new?

A solr backend and an admin configuration tab.

# How should this be tested?

Switch between Sparql and Solr and still the compounds should work the same.

Check out the Solr Backend tab on the Compound Object Solution Pack admin page.

# Additional Notes:

Example:
* Does this change require documentation to be updated? unsure
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@Islandora/7-x-1-x-committers
