### PR TITLE
Address ISLANDORA-2327; collection pager is not accurate

### DIFF
--- a/islandora_solr.module
+++ b/islandora_solr.module
@@ -616,3 +616,15 @@ function islandora_solr_islandora_breadcrumbs_backends() {
     ),
   );
 }
+
+/**
+ * Implements hook_preprocess().
+ */
+function islandora_solr_preprocess_islandora_objects_subset(&$variables) {
+  $backend = variable_get('islandora_basic_collection_display_backend', ISLANDORA_BASIC_COLLECTION_LEGACY_BACKEND);
+  if ($backend == 'islandora_solr_query_backend') {
+    // Set the collection pager limit based on correct page size.
+    global $_islandora_solr_queryclass;
+    $variables['limit'] = $_islandora_solr_queryclass->solrLimit;
+  }
+}


### PR DESCRIPTION
Collection pager is not accurate when Solr page size does not match collection page size and Solr is generating collection displays.

The collection pager doesn't have enough pages or has too many pages for the number of objects in the collection depending on Solr page size and Collection SP page size.

**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2327

* Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)

# What does this Pull Request do?
Uses a preprocess hook to determine the Solr page size.

# What's new?
Fixes the pager limit to match the actual page size.

# How should this be tested?
See JIRA ticket for test case.

# Additional Notes:
* Does this change require documentation to be updated?  No
* Does this change add any new dependencies?  No
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? No

# Interested parties
Tagging @whikloj as the maintainer  
