### PR TITLE
Create a more stable islandora search link

### DIFF
--- a/includes/explore.inc
+++ b/includes/explore.inc
@@ -29,11 +29,14 @@ function islandora_solr_explore_generate_links() {
     }
     $qp->executeQuery(FALSE);
     foreach ($expore_config as $index => $option) {
-      $url = htmlspecialchars(urlencode($option['filter']));
       $links[] = l(
         htmlentities($option['label']),
-        "islandora/search/$url",
-        array()
+        'islandora/search',
+         array(
+           'query' => array(
+             'f' => array($option['filter']),
+           ),
+         )
       ) . '&nbsp;<span>(' . htmlentities($qp->islandoraSolrResult['facet_counts']['facet_queries'][$option['filter']]) . ')</span>';
     }
   }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2360

# What does this Pull Request do?
This pull request will allow Islandora Solr Search's Explore block to create more stable Solr search links. These links are properly escaped and do not send Solr malformed queries.

# What's new?
Changes the way the Explore block creates the solr query url. This is done by extracting the given filters and adding them to the filter query portion of the query. Example: `search?f[0]=RELS_EXT_hasModel_uri_ms:("info:fedora/islandora:sp_basic_image")` 
instead of 
`search/RELS_EXT_hasModel_uri_ms%253A%2528%2522info%253Afedora%252Fislandora%253Asp_basic_image%2522%2529%2B`.

# How should this be tested?
Before pulling down the code:
* Navigate to Structure > Blocks and find 'Islandora explore' block. 
* Add to a region (Content recommended)
* Click configure on the block and under 'Setup Display Facets', add a Label and Filter query. ex. 

> RELS_EXT_hasModel_uri_ms:("info:fedora/islandora:sp_basic_image" OR "info:fedora/islandora:sp_large_image")

* Add and then save the block.
* Navigate to the Explore block and click the created link.
* Following this, click one of the created facet filter links.

Functionality is inconsistent such as spaces outside of quotes being submitted as Solr as plus signs. Pull the code and observe the explore block's functionality again.

# Interested parties
@adam-vessey 
@nhart 
@Islandora/7-x-1-x-committers
@whikloj 

----
Elkeno Jones
_Developer_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**
