### PR TITLE
ISLANDORA-2373: Hide debug message unless user has permission

### DIFF
--- a/SolrPhpClient/Apache/Solr/Service.php
+++ b/SolrPhpClient/Apache/Solr/Service.php
@@ -330,8 +330,11 @@ class Apache_Solr_Service
 		}
 		
 		// Islandora: dump solr query address in debug mode
-		if ( variable_get('islandora_solr_debug_mode', 0) ) drupal_set_message(l('solr query',$url."&indent=on&debugQuery=true"));
-
+		if (variable_get('islandora_solr_debug_mode', 0)) {
+                  if (user_access('view solr debug')) {
+                    drupal_set_message(l('solr query',$url."&indent=on&debugQuery=true"));
+                  }
+                }
 		//$http_response_header is set by file_get_contents
 		$response = new Apache_Solr_Response(@file_get_contents($url, false, $this->_getContext), $http_response_header, $this->_createDocuments, $this->_collapseSingleValueArrays);
 

--- a/SolrPhpClient/Apache/Solr/Service.php
+++ b/SolrPhpClient/Apache/Solr/Service.php
@@ -330,10 +330,8 @@ class Apache_Solr_Service
 		}
 		
 		// Islandora: dump solr query address in debug mode
-		if (variable_get('islandora_solr_debug_mode', 0)) {
-                  if (user_access('view solr debug')) {
-                    drupal_set_message(l('solr query',$url."&indent=on&debugQuery=true"));
-                  }
+		if (variable_get('islandora_solr_debug_mode', 0) && user_access('view islandora solr debug')) {
+                  drupal_set_message(l('solr query',$url."&indent=on&debugQuery=true"));
                 }
 		//$http_response_header is set by file_get_contents
 		$response = new Apache_Solr_Response(@file_get_contents($url, false, $this->_getContext), $http_response_header, $this->_createDocuments, $this->_collapseSingleValueArrays);

--- a/includes/results.inc
+++ b/includes/results.inc
@@ -80,10 +80,8 @@ class IslandoraSolrResults {
 
     // Debug (will be removed).
     $elements['solr_debug'] = '';
-    if (variable_get('islandora_solr_debug_mode', 0)) {
-      if (user_access('view solr debug')) {
-        $elements['solr_debug'] = $this->printDebugOutput($islandora_solr_result);
-      }
+    if (variable_get('islandora_solr_debug_mode', 0) && user_access('view islandora solr debug')) {
+      $elements['solr_debug'] = $this->printDebugOutput($islandora_solr_result);
     }
 
     // Rendered secondary display profiles.

--- a/includes/results.inc
+++ b/includes/results.inc
@@ -81,7 +81,9 @@ class IslandoraSolrResults {
     // Debug (will be removed).
     $elements['solr_debug'] = '';
     if (variable_get('islandora_solr_debug_mode', 0)) {
-      $elements['solr_debug'] = $this->printDebugOutput($islandora_solr_result);
+      if (user_access('view solr debug')) {
+        $elements['solr_debug'] = $this->printDebugOutput($islandora_solr_result);
+      }
     }
 
     // Rendered secondary display profiles.

--- a/islandora_solr.module
+++ b/islandora_solr.module
@@ -136,7 +136,7 @@ function islandora_solr_permission() {
       'title' => t('Administer Solr'),
       'description' => t('Administer settings for the Solr client.'),
     ),
-    'view solr debug' => array(
+    'view islandora solr debug' => array(
       'title' => t('View Solr debug messages'),
       'description' => t('See printed Solr queries when debug mode is turned on.'),
     ),
@@ -366,11 +366,9 @@ function islandora_solr($query = NULL, $params = NULL) {
   }
 
   // Debug dump.
-  if (variable_get('islandora_solr_debug_mode', 0)) {
-    if (user_access('view solr debug')) {
-      $message = t('Parameters: <br /><pre>!debug</pre>', array('!debug' => print_r($_islandora_solr_queryclass->solrParams, TRUE)));
-      drupal_set_message(filter_xss($message, array('pre', 'br')), 'status');
-    }
+  if (variable_get('islandora_solr_debug_mode', 0) && user_access('view islandora solr debug')) {
+    $message = t('Parameters: <br /><pre>!debug</pre>', array('!debug' => print_r($_islandora_solr_queryclass->solrParams, TRUE)));
+    drupal_set_message(filter_xss($message, array('pre', 'br')), 'status');
   }
   return $output;
 }

--- a/islandora_solr.module
+++ b/islandora_solr.module
@@ -136,6 +136,10 @@ function islandora_solr_permission() {
       'title' => t('Administer Solr'),
       'description' => t('Administer settings for the Solr client.'),
     ),
+    'view solr debug' => array(
+      'title' => t('View Solr debug messages'),
+      'description' => t('See printed Solr queries when debug mode is turned on.'),
+    ),
   );
 }
 
@@ -363,8 +367,10 @@ function islandora_solr($query = NULL, $params = NULL) {
 
   // Debug dump.
   if (variable_get('islandora_solr_debug_mode', 0)) {
-    $message = t('Parameters: <br /><pre>!debug</pre>', array('!debug' => print_r($_islandora_solr_queryclass->solrParams, TRUE)));
-    drupal_set_message(filter_xss($message, array('pre', 'br')), 'status');
+    if (user_access('view solr debug')) {
+      $message = t('Parameters: <br /><pre>!debug</pre>', array('!debug' => print_r($_islandora_solr_queryclass->solrParams, TRUE)));
+      drupal_set_message(filter_xss($message, array('pre', 'br')), 'status');
+    }
   }
   return $output;
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2373

# What does this Pull Request do?

Adds a new permission to Islandora Solr Search: View Solr Debug.

# What's new?

When Debug Mode is turned on, all debug messages (solr query, etc.) are hidden from users who don't have the 'view solr debug' permission. This allows administrators to debug Solr in a live site without affecting other users.

# How should this be tested?

- Turn on Debug Mode (Islandora -> Solr settings, Other, check "Debug mode")
- Run a search as an anonymous user and as admin, see debug info displaying
- Checkout this branch
- Assign permissions
- Run the same search again as permitted user and as anonymous user. Permitted user's results should not change; anonymous user should not see the debug messages.


# Interested parties
@Islandora/7-x-1-x-committers
