### PR TITLE
Pass an empty array instead of NULL

### DIFF
--- a/includes/results.inc
+++ b/includes/results.inc
@@ -74,7 +74,7 @@ class IslandoraSolrResults {
     $elements['solr_pager'] = theme('pager', array(
       'tags' => NULL,
       'element' => 0,
-      'parameters' => NULL,
+      'parameters' => array(),
       'quantity' => 5,
     ));
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2378

# What does this Pull Request do?

Passes `array()` instead of `NULL`.

Because the `parameters` argument is described in Drupal documentation as:
> parameters: An associative array of query string parameters to append to the pager link.

# What's new?
This is apparently only a problem in PHP 7.2 so you might have to do some work to test it. But this change should have no impact on anything except making PHP 7.2 not explode.

# How should this be tested?

Test with PHP < 7.2 and see nothing change
Test with PHP == 7.2 and see explosions disappear when viewing pager in solr.

# Additional Notes:

Example:
* Does this change the interface, add a new feature, or otherwise change behaviours that would require updating documentation? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@DiegoPino @Islandora/7-x-1-x-committers
