### PR TITLE
Adjusting theme pager call to be PHP 7.2 compliant

### DIFF
--- a/includes/results.inc
+++ b/includes/results.inc
@@ -74,7 +74,7 @@ class IslandoraSolrResults {
     $elements['solr_pager'] = theme('pager', array(
       'tags' => NULL,
       'element' => 0,
-      'parameters' => NULL,
+      'parameters' => array(),
       'quantity' => 5,
     ));
 


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-2400)

# What does this Pull Request do?
This pull is to fix a warning thrown on Ubuntu (18.04) boxes running PHP 7.2. When viewing search results on the second page (subsequent pages) of the pager, the following warning is thrown:

```Warning - count(): Parameter must be an array or an object that implements Countable```

This warning is thrown from line 607 of theme_pager_link() (found in drupal/includes/pager.inc). Following the back-trace led me to the use of NULL as the default param for theme_pager as the culprit. Of course that's not countable, so here we are.

According to the [theme_pager](https://api.drupal.org/api/drupal/includes%21pager.inc/function/theme_pager/7.x), the 'parameters' variable should be an array(). 

I should note i do not believe the version of Ubuntu is necessarily important, just the version of PHP it ships with is 7.2.

# What's new?
Changing the default parameter in the theme_pager call  to be an empty array, instead of NULL.

# How should this be tested?
- Install islandora on an Ubuntu box running 18.04 with PHP version 7.2
- Preform a search result that has multiple pages
- Navigate to the second page in the result set

# Interested parties
Tag @whikloj
