### PR TITLE
Print nice error message to the screen (without 5.3.3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,20 @@ matrix:
     - php: 5.3.3
       dist: precise
       env: FEDORA_VERSION="3.8.1"
+  allow_failures:
+  # 5.3.3 can fail now.
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.5"
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.6.2"
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.7.0"
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.8.1"
 php:
   - 5.4
   - 5.5

--- a/SolrPhpClient/Apache/Solr/Service.php
+++ b/SolrPhpClient/Apache/Solr/Service.php
@@ -328,13 +328,13 @@ class Apache_Solr_Service
 			// use the default timeout pulled from default_socket_timeout otherwise
 			stream_context_set_option($this->_getContext, 'http', 'timeout', $this->_defaultTimeout);
 		}
-		
+
 		// Islandora: dump solr query address in debug mode
 		if (variable_get('islandora_solr_debug_mode', 0) && user_access('view islandora solr debug')) {
                   drupal_set_message(l('solr query',$url."&indent=on&debugQuery=true"));
                 }
 		//$http_response_header is set by file_get_contents
-		$response = new Apache_Solr_Response(@file_get_contents($url, false, $this->_getContext), $http_response_header, $this->_createDocuments, $this->_collapseSingleValueArrays);
+		$response = new Apache_Solr_Response(@file_get_contents($url, false, $this->_getContext), @$http_response_header, $this->_createDocuments, $this->_collapseSingleValueArrays);
 
 		if ($response->getHttpStatus() != 200)
 		{

--- a/includes/admin.inc
+++ b/includes/admin.inc
@@ -153,6 +153,15 @@ function islandora_solr_admin_index_settings($form, &$form_state) {
     '#default_value' => variable_get('islandora_solr_force_update_index_after_object_purge', 0),
   );
 
+  $form['solr_ajax_wrapper']['islandora_solr_technical_difficulties_message'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Solr unavailable message.'),
+    '#description' => t('When Solr throws an Exception this message is displayed to the users.'),
+    '#size' => 150,
+    '#weight' => 10,
+    '#default_value' => variable_get('islandora_solr_technical_difficulties_message', ISLANDORA_SOLR_DIFFICULTIES_MESSAGE),
+  );
+
   // Actions.
   $form['actions'] = array(
     '#type' => 'actions',
@@ -200,6 +209,7 @@ function _islandora_solr_admin_index_settings_submit($form, &$form_state) {
       variable_set('islandora_solr_url', $form_state['values']['islandora_solr_url']);
       variable_set('islandora_solr_request_handler', $form_state['values']['islandora_solr_request_handler']);
       variable_set('islandora_solr_force_update_index_after_object_purge', $form_state['values']['islandora_solr_force_update_index_after_object_purge']);
+      variable_set('islandora_solr_technical_difficulties_message', $form_state['values']['islandora_solr_technical_difficulties_message']);
       drupal_set_message(t('The Solr configuration options have been saved.'));
       break;
 
@@ -207,6 +217,7 @@ function _islandora_solr_admin_index_settings_submit($form, &$form_state) {
       variable_del('islandora_solr_url');
       variable_del('islandora_solr_request_handler');
       variable_del('islandora_solr_force_update_index_after_object_purge');
+      variable_del('islandora_solr_technical_difficulties_message');
       drupal_set_message(t('The configuration options have been reset to their default values.'));
       break;
   }

--- a/includes/breadcrumbs.inc
+++ b/includes/breadcrumbs.inc
@@ -118,14 +118,8 @@ function islandora_solr_get_breadcrumb_parent($pid) {
   $solr_build->solrParams = islandora_solr_remove_base_filters($solr_build->solrParams);
   $solr_build->solrParams = islandora_solr_clean_compound_filters($solr_build->solrParams);
 
-  try {
-    $solr_build->executeQuery(FALSE);
-    $results = (array) $solr_build->islandoraSolrResult['response']['objects'];
-  }
-  catch (Exception $e) {
-    $results = array();
-    drupal_set_message(check_plain(t('Error searching Solr index')) . ' ' . $e->getMessage(), 'error', FALSE);
-  }
+  $solr_build->executeQuery(FALSE);
+  $results = (array) $solr_build->islandoraSolrResult['response']['objects'];
 
   $find_solr_value = function($o, $field) {
     if (isset($o[$field])) {

--- a/includes/compound_backend.inc
+++ b/includes/compound_backend.inc
@@ -90,15 +90,10 @@ function islandora_solr_compound_object_query($pid) {
     $start += 1;
     $solr_build->solrStart = $start * $rows;
     $solr_build->solrLimit = $rows;
-    try {
-      $solr_build->executeQuery(FALSE);
-      $results = (array) $solr_build->islandoraSolrResult['response']['objects'];
-      $constituents = array_merge($constituents, $results);
-    }
-    catch (Exception $e) {
-      drupal_set_message(check_plain(t('Error searching Solr index')) . ' ' . $e->getMessage(), 'error', FALSE);
-      break;
-    }
+    $solr_build->executeQuery(FALSE);
+    $results = (array) $solr_build->islandoraSolrResult['response']['objects'];
+    $constituents = array_merge($constituents, $results);
+
     if (is_null($total) && isset($solr_build->islandoraSolrResult['response']['numFound'])) {
       $total = $solr_build->islandoraSolrResult['response']['numFound'];
     }

--- a/includes/query_processor.inc
+++ b/includes/query_processor.inc
@@ -399,7 +399,7 @@ class IslandoraSolrQueryProcessor {
       $results = $solr->search($solr_query, $this->solrStart, $this->solrLimit, $this->solrParams, $method);
     }
     catch (Exception $e) {
-      drupal_set_message(check_plain(t('Error searching Solr index')) . ' ' . $e->getMessage(), 'error');
+      islandora_solr_technical_difficulties($e);
     }
 
     $object_results = array();

--- a/islandora_solr.install
+++ b/islandora_solr.install
@@ -66,6 +66,7 @@ function islandora_solr_uninstall() {
     'islandora_solr_simple_search_label_title',
     'islandora_solr_compound_relationship_field',
     'islandora_solr_compound_sequence_pattern',
+    'islandora_solr_technical_difficulties_message',
   ));
   array_walk($variables, 'variable_del');
 }

--- a/islandora_solr.module
+++ b/islandora_solr.module
@@ -641,12 +641,12 @@ function islandora_solr_preprocess_islandora_objects_subset(&$variables) {
  */
 function islandora_solr_technical_difficulties(Exception $e) {
   // Only report the error once per screen.
-  $islandora_solr_error_reported = &drupal_static(__FUNCTION__, false);
+  $islandora_solr_error_reported = &drupal_static(__FUNCTION__, FALSE);
 
-  if ($islandora_solr_error_reported !== true) {
+  if ($islandora_solr_error_reported !== TRUE) {
     $message = "We are experiencing technical difficulties at this time and are working to fix the problem. Please try back later.";
-    drupal_set_message(t($message), 'warning');
-    watchdog("manidora", "Received exception @code: @message\nLine: @line in file: @file", array(
+    drupal_set_message(t("@message", array('@message' => $message)), 'warning');
+    watchdog("islandora_solr", "Received exception @code: @message\nLine: @line in file: @file", array(
       '@code' => $e->getCode(),
       '@message' => $e->getMessage(),
       '@file' => $e->getFile(),

--- a/islandora_solr.module
+++ b/islandora_solr.module
@@ -15,6 +15,8 @@ const ISLANDORA_SOLR_FACET_BUCKET_CLASSES_HOOK_BASE = 'islandora_solr_facet_buck
 
 const ISLANDORA_SOLR_BREADCRUMB_BACKEND = 'islandora_solr_breadcrumb_backend';
 
+const ISLANDORA_SOLR_DIFFICULTIES_MESSAGE = "We are experiencing technical difficulties at this time and are working to fix the problem. Please try back later.";
+
 // Includes functions for common db queries.
 require_once dirname(__FILE__) . '/includes/db.inc';
 // Includes functions for common tasks.
@@ -644,8 +646,9 @@ function islandora_solr_technical_difficulties(Exception $e) {
   $islandora_solr_error_reported = &drupal_static(__FUNCTION__, FALSE);
 
   if ($islandora_solr_error_reported !== TRUE) {
-    $message = "We are experiencing technical difficulties at this time and are working to fix the problem. Please try back later.";
-    drupal_set_message(t("@message", array('@message' => $message)), 'warning');
+    drupal_set_message(t("@message", array(
+      '@message' => variable_get('islandora_solr_technical_difficulties_message', ISLANDORA_SOLR_DIFFICULTIES_MESSAGE)
+    )), 'warning');
     watchdog("islandora_solr", "Received exception @code: @message\nLine: @line in file: @file", array(
       '@code' => $e->getCode(),
       '@message' => $e->getMessage(),

--- a/islandora_solr.module
+++ b/islandora_solr.module
@@ -632,3 +632,26 @@ function islandora_solr_preprocess_islandora_objects_subset(&$variables) {
     $variables['limit'] = $_islandora_solr_queryclass->solrLimit;
   }
 }
+
+/**
+ * Make nice text for screen and log the exception to watchdog.
+ *
+ * @param \Exception $e
+ *   The exception.
+ */
+function islandora_solr_technical_difficulties(Exception $e) {
+  // Only report the error once per screen.
+  $islandora_solr_error_reported = &drupal_static(__FUNCTION__, false);
+
+  if ($islandora_solr_error_reported !== true) {
+    $message = "We are experiencing technical difficulties at this time and are working to fix the problem. Please try back later.";
+    drupal_set_message(t($message), 'warning');
+    watchdog("manidora", "Received exception @code: @message\nLine: @line in file: @file", array(
+      '@code' => $e->getCode(),
+      '@message' => $e->getMessage(),
+      '@file' => $e->getFile(),
+      '@line' => $e->getLine(),
+    ), WATCHDOG_ERROR);
+    $islandora_solr_error_reported = TRUE;
+  }
+}


### PR DESCRIPTION
This is #362 (the cleaning house remix).

Reminder: PHP 5.3 became End Of Life 4 years, 8 months ago.
https://www.php.net/eol.php

# Interested parties
@DiegoPino, @jonathangreen @Islandora/7-x-1-x-committers and anyone with a valid reason to not allow 5.3.3 to fail.
