### PR TITLE
Set separate result limit in RSS from Display page

### DIFF
--- a/islandora_solr_config/includes/admin.inc
+++ b/islandora_solr_config/includes/admin.inc
@@ -31,6 +31,7 @@ function islandora_solr_config_admin_rss_settings($form, &$form_state) {
     'managingEditor' => '',
     'webMaster' => '',
   ));
+  $rss_limit = variable_get('islandora_solr_config_rss_limit', 50);
 
   $form = array(
     '#tree' => TRUE,
@@ -110,6 +111,12 @@ function islandora_solr_config_admin_rss_settings($form, &$form_state) {
     '#description' => t('Email address for person responsible for technical issues relating to channel.'),
     '#default_value' => $rss_channel['webMaster'] ? $rss_channel['webMaster'] : '',
   );
+  $form['rss_limit'] = array(
+    '#type' => 'textfield',
+    '#title' => 'RSS results limit',
+    '#description' => 'Maximum number of results via RSS.',
+    '#default_value' => $rss_limit,
+  );
   $form['buttons']['submit'] = array(
     '#type' => 'submit',
     '#value' => t('Save'),
@@ -120,7 +127,6 @@ function islandora_solr_config_admin_rss_settings($form, &$form_state) {
     '#value' => t('Reset to defaults'),
     '#weight' => 51,
   );
-
   return $form;
 }
 
@@ -135,10 +141,11 @@ function islandora_solr_config_admin_rss_settings_submit($form, &$form_state) {
     // Get values.
     $rss_item = $form_state['values']['rss_item'];
     $rss_channel = $form_state['values']['rss_channel'];
-
+    $rss_limit = $form_state['values']['rss_limit'];
     // Set variable.
     variable_set('islandora_solr_config_rss_item', $rss_item);
     variable_set('islandora_solr_config_rss_channel', $rss_channel);
+    variable_set('islandora_solr_config_rss_limit', $rss_limit);
   }
 
   // On reset.

--- a/islandora_solr_config/includes/rss_results.inc
+++ b/islandora_solr_config/includes/rss_results.inc
@@ -31,6 +31,8 @@ class IslandoraSolrResultsRSS extends IslandoraSolrResults {
     global $base_url;
 
     drupal_add_http_header('Content-Type', 'application/rss+xml; charset=utf-8');
+    $islandora_solr_query->solrLimit = variable_get('islandora_solr_config_rss_limit', 50);
+    $islandora_solr_query->executeQuery();
 
     // Get raw results.
     $solr_result = $islandora_solr_query->islandoraSolrResult;

--- a/islandora_solr_config/islandora_solr_config.install
+++ b/islandora_solr_config/islandora_solr_config.install
@@ -14,6 +14,7 @@ function islandora_solr_config_uninstall() {
   $variables = array(
     'islandora_solr_table_profile_display_row_no',
     'islandora_solr_table_profile_table_class',
+    'islandora_solr_config_rss_limit',
   );
   foreach ($variables as $variable) {
     variable_del($variable);


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-2437)

# What does this Pull Request do?

Sets a separate solrLimit on the RSS results page from the results given via an in-website query. Resolves the problem where the number of RSS results, which cannot be paged, is tied to the number of results in the UI, which are paged.

# What's new?
A new admin field on the RSS tab where the RSS Solr limit can be set. This will set the number of results that appear in the RSS results.

# How should this be tested?

* Enable the RSS option in the Solr settings
* Set the results limit to 20
* In the 7.x branch, run a search that should return more than 20 results
* Click the RSS button and see 20 results - the `<item>` tag will appear 20 times
* Check out this branch, and set the RSS results to 100
* Refresh the RSS result page
* You should now see more than 20 results

# Additional Notes:
This should not impact any other features or functionality; it just lets you change how many results you get in RSS.

# Interested parties
@Islandora/7-x-1-x-committers @dannylamb @whikloj 