### PR TITLE
Add hook to alter Solr facets

### DIFF
--- a/includes/results.inc
+++ b/includes/results.inc
@@ -1097,8 +1097,8 @@ class IslandoraSolrFacets {
       $buckets[] = $link;
     }
 
-    drupal_alter('islandora_solr_facet_variables', $buckets);
-
+    drupal_alter('islandora_solr_facet_variables', $buckets, $facet_field);
+dd($facet_field);
     // Show more link.
     if (count($buckets) > $soft_limit) {
       // Create hook_islandora_solr_facet_variables_alter().

--- a/includes/results.inc
+++ b/includes/results.inc
@@ -1097,10 +1097,11 @@ class IslandoraSolrFacets {
       $buckets[] = $link;
     }
 
+    drupal_alter('islandora_solr_facet_variables', $buckets);
+
     // Show more link.
     if (count($buckets) > $soft_limit) {
       // Create hook_islandora_solr_facet_variables_alter().
-      drupal_alter('islandora_solr_facet_variables', $buckets);
       $buckets_visible = array_slice($buckets, 0, $soft_limit);
       $buckets_hidden = array_slice($buckets, $soft_limit);
       $this->content .= theme('islandora_solr_facet', array(

--- a/includes/results.inc
+++ b/includes/results.inc
@@ -1099,6 +1099,8 @@ class IslandoraSolrFacets {
 
     // Show more link.
     if (count($buckets) > $soft_limit) {
+      // Create hook_islandora_solr_facet_variables_alter().
+      drupal_alter('islandora_solr_facet_variables', $buckets);
       $buckets_visible = array_slice($buckets, 0, $soft_limit);
       $buckets_hidden = array_slice($buckets, $soft_limit);
       $this->content .= theme('islandora_solr_facet', array(

--- a/islandora_solr.api.php
+++ b/islandora_solr.api.php
@@ -191,6 +191,15 @@ function hook_islandora_solr_search_rss_item_alter($item, $doc) {
 }
 
 /**
+ * Implements hook_islandora_solr_facet_variables_alter().
+ */
+function hook_islandora_solr_facet_variables_alter(&$buckets) {
+  foreach ($buckets AS $bucket) {
+    $bucket['link'] = $new_link;
+  }
+}
+
+/**
  * Allow altering of Solr facet buckets links (link, plus, minus).
  *
  * The original intention of this hook is to allow one to implement AJAX

--- a/islandora_solr.api.php
+++ b/islandora_solr.api.php
@@ -193,9 +193,11 @@ function hook_islandora_solr_search_rss_item_alter($item, $doc) {
 /**
  * Implements hook_islandora_solr_facet_variables_alter().
  */
-function hook_islandora_solr_facet_variables_alter(&$buckets) {
+function hook_islandora_solr_facet_variables_alter(&$buckets, &$facet_field) {
   foreach ($buckets AS $bucket) {
-    $bucket['link'] = $new_link;
+    if ($facet_field == $configured_facet_field) {
+      $bucket['link'] = $new_link;
+    }
   }
 }
 

--- a/islandora_solr.api.php
+++ b/islandora_solr.api.php
@@ -191,7 +191,13 @@ function hook_islandora_solr_search_rss_item_alter($item, $doc) {
 }
 
 /**
- * Implements hook_islandora_solr_facet_variables_alter().
+ * This hook allows modules to modify the facets returned from a search.
+ * You may for example wish to modify the facet's display text.
+ *
+ * @param array $buckets
+ *   See the hook definition below.
+ * @param $facet_field
+ *   The Solr field used by the facet being returned.
  */
 function hook_islandora_solr_facet_variables_alter(&$buckets, &$facet_field) {
   foreach ($buckets AS $bucket) {

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -99,7 +99,6 @@ function template_preprocess_islandora_solr_facet(&$variables) {
   if ($variables['hidden']) {
     $variables['classes_array'][] = 'hidden';
   }
-//  drupal_alter('islandora_solr_facet_variables', $variables['buckets']);
 }
 
 /**

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -99,6 +99,7 @@ function template_preprocess_islandora_solr_facet(&$variables) {
   if ($variables['hidden']) {
     $variables['classes_array'][] = 'hidden';
   }
+  drupal_alter('islandora_solr_facet_variables', $buckets);
 }
 
 /**

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -99,7 +99,7 @@ function template_preprocess_islandora_solr_facet(&$variables) {
   if ($variables['hidden']) {
     $variables['classes_array'][] = 'hidden';
   }
-  drupal_alter('islandora_solr_facet_variables', $buckets);
+//  drupal_alter('islandora_solr_facet_variables', $variables['buckets']);
 }
 
 /**


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-2493)

# What does this Pull Request do?

Creates a new hook that lets you modify the output of your Solr facets. For example, if you wanted to modify the link, you could do so.

# What's new?
New hook: hook_islandora_solr_facet_variables_alter($buckets) can be called.

# How should this be tested?

- Download islandora_metadata_extras and check out the facet_labels branch: https://github.com/bondjimbond/islandora_metadata_extras/tree/facet_labels
- Take a known value in your facets and configure a replacement in the module (Islandora Utility Modules -> Metadata Extras, check "Replace facet values with configured text", and enter `oldvalue|newvalue`
- Run a search, and see that the displaying for your facet has changed

# Interested parties
@whikloj @mjordan @Islandora/7-x-1-x-committers
