### PR TITLE
Add label to facet classes alter hook

### DIFF
--- a/includes/blocks.inc
+++ b/includes/blocks.inc
@@ -972,6 +972,7 @@ function islandora_solr_sort() {
           ),
           'query' => $query,
           'path' => $path,
+          'label' => $label,
         ),
       );
       $attr =& $attributes['sort']['attr'];
@@ -987,7 +988,7 @@ function islandora_solr_sort() {
 
       // XXX: We're not using l() because of
       // @link http://drupal.org/node/41595 active classes. @endlink
-      $item = '<a' . drupal_attributes($attr) . '>' . $label . ' ' . $indicator . '</a>';
+      $item = '<a' . drupal_attributes($attr) . '>' . $attributes['sort']['label'] . ' ' . $indicator . '</a>';
 
       // Add link to list.
       $list_items[] = $item;

--- a/includes/results.inc
+++ b/includes/results.inc
@@ -226,6 +226,7 @@ class IslandoraSolrResults {
           'attr' => array(),
           'path' => $path_minus,
           'query' => $query_minus,
+          'label' => '(-)',
         ),
       );
       $attr_minus =& $attributes['minus']['attr'];
@@ -240,7 +241,7 @@ class IslandoraSolrResults {
       // XXX: We are not using l() because of active classes:
       // @see http://drupal.org/node/41595
       // Create link.
-      $query_list[] = '<a' . drupal_attributes($attributes['minus']['attr']) . '>(-)</a> ' . check_plain($query_value);
+      $query_list[] = '<a' . drupal_attributes($attributes['minus']['attr']) . '>' . $attributes['minus']['label'] . '</a> ' . check_plain($query_value);
 
       // Add wrap and list.
       $output .= '<div class="islandora-solr-query-wrap">';
@@ -287,6 +288,7 @@ class IslandoraSolrResults {
             'attr' => array(),
             'path' => $path,
             'query' => $query_minus,
+            'label' => '(-)',
           ),
         );
         $attr_minus =& $attributes['minus']['attr'];
@@ -301,7 +303,7 @@ class IslandoraSolrResults {
         // XXX: We are not using l() because of active classes:
         // @see http://drupal.org/node/41595
         // Create link.
-        $filter_list[] = '<a' . drupal_attributes($attributes['minus']['attr']) . '>(-)</a> ' . $symbol . ' ' . check_plain($filter_string);
+        $filter_list[] = '<a' . drupal_attributes($attributes['minus']['attr']) . '>' . $attributes['minus']['label'] . '</a> ' . $symbol . ' ' . check_plain($filter_string);
 
       }
 
@@ -1064,12 +1066,15 @@ class IslandoraSolrFacets {
       $attributes = array(
         'link' => array(
           'path' => $path,
+          'label' => $bucket,
         ),
         'plus' => array(
           'path' => $path,
+          'label' => '+',
         ),
         'minus' => array(
           'path' => $path,
+          'label' => '-',
         ),
       );
       $attributes['link']['attr'] = $attributes['minus']['attr'] = $attributes['plus']['attr'] = array('rel' => 'nofollow', 'title' => $bucket);
@@ -1090,10 +1095,10 @@ class IslandoraSolrFacets {
       // XXX: We are not using l() because of active classes:
       // @see http://drupal.org/node/41595
       // Create link.
-      $link['link'] = '<a' . drupal_attributes($attributes['link']['attr']) . '>' . $bucket . '</a>';
+      $link['link'] = '<a' . drupal_attributes($attributes['link']['attr']) . '>' . $attributes['link']['label'] . '</a>';
       $link['count'] = $count;
-      $link['link_plus'] = '<a' . drupal_attributes($attributes['plus']['attr']) . '>+</a>';
-      $link['link_minus'] = '<a' . drupal_attributes($attributes['minus']['attr']) . '>-</a>';
+      $link['link_plus'] = '<a' . drupal_attributes($attributes['plus']['attr']) . '>' . $attributes['plus']['label'] . '</a>';
+      $link['link_minus'] = '<a' . drupal_attributes($attributes['minus']['attr']) . '>' . $attributes['minus']['label'] . '</a>';
       $buckets[] = $link;
     }
 

--- a/islandora_solr.api.php
+++ b/islandora_solr.api.php
@@ -207,6 +207,7 @@ function hook_islandora_solr_search_rss_item_alter($item, $doc) {
  *   - attr: The an associative array of attributes as accepted by
  *     drupal_attributes() to set on the generated "a" tag.
  *   - query: An associative array of query parameters.
+ *   - label: The text to display for the link.
  * @param IslandoraSolrQueryProcessor $query_processor
  *   The query processor for the current query (with results attached).
  */


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-2493)

This would supplant #369, modifying an existing hook instead of adding a whole new one. This approach, I feel, is better.

# What does this Pull Request do?

Adds the facet label to the alterable values provided in hook_islandora_solr_facet_bucket_classes_alter().

# What's new?

Just adds the 'label' attribute to the alter hook and makes it available to be modified.

# How should this be tested?

- Download islandora_metadata_extras and check out the `adam` branch: https://github.com/bondjimbond/islandora_metadata_extras/tree/adam
- Take a known value in your facets and configure a replacement in the module (Islandora Utility Modules -> Metadata Extras, check "Replace facet values with configured text", and enter `oldvalue|newvalue`
- Run a search, and see that the displaying for your facet has changed

# Interested parties
@whikloj @DiegoPino @adam-vessey @Islandora/7-x-1-x-committers
