### PR TITLE
Adding soft limit check

### DIFF
--- a/includes/results.inc
+++ b/includes/results.inc
@@ -1103,7 +1103,7 @@ class IslandoraSolrFacets {
     }
 
     // Show more link.
-    if (count($buckets) > $soft_limit) {
+    if (count($buckets) > $soft_limit && $soft_limit > 0) {
       $buckets_visible = array_slice($buckets, 0, $soft_limit);
       $buckets_hidden = array_slice($buckets, $soft_limit);
       $this->content .= theme('islandora_solr_facet', array(


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/ISLANDORA-2524

# What does this Pull Request do?
Adds ability to disable `Soft Limit` by setting value to 0, as indicated in admin menu field configuration.

# What's new?
The soft limit check just needed another condition in the if statement to also check that `$soft_limit > 0`. The facet settings section of the admin form for islandora_solr specifies in the `Soft Limit` description to `Use 0 to disable.`, though setting the limit to 0 displayed no facets and only a "MORE..." link to expand the facet options selection. Adding this check to the existing soft limit check displays all facets(Up to the configured Maximum Limit) when setting `Soft Limit` configuration to 0.

# How should this be tested?
Navigate to the Solr Settings -> Facet Settings admin configuration page
Set 'Soft Limit' to 0
Perform a solr search, note that no facets are obscured by a "MORE..." link

# Interested parties
@Islandora/7-x-1-x-committers